### PR TITLE
feat: add github templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,33 @@
+---
+name: Bug Report
+about: Create a report to help us improve
+title: '[BUG] '
+labels: bug
+assignees: ''
+---
+
+## Bug Description
+<!-- A clear and concise description of what the bug is -->
+
+## Steps to Reproduce
+1. 
+2. 
+3. 
+4. 
+
+## Expected Behavior
+<!-- A clear and concise description of what you expected to happen -->
+
+## Actual Behavior
+<!-- A clear and concise description of what actually happened -->
+
+## Screenshots
+<!-- If applicable, add screenshots to help explain your problem -->
+
+## Environment
+- OS: [e.g. Windows, macOS, Linux]
+- Browser (if applicable): [e.g. Chrome, Firefox]
+- Version/Commit: [e.g. v1.0.0 or commit hash]
+
+## Additional Context
+<!-- Add any other context about the problem here -->

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,22 @@
+---
+name: Feature Request
+about: Suggest an idea for this project
+title: '[FEATURE] '
+labels: enhancement
+assignees: ''
+---
+
+## Feature Description
+<!-- A clear and concise description of the feature you're requesting -->
+
+## Problem Statement
+<!-- Describe the problem or limitation that this feature would address -->
+
+## Proposed Solution
+<!-- Describe how you envision this feature working -->
+
+## Alternatives Considered
+<!-- Describe any alternative solutions or features you've considered -->
+
+## Additional Context
+<!-- Add any other context, screenshots, or examples about the feature request here -->

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,26 @@
+## Description
+<!-- Provide a brief description of the changes introduced by this PR -->
+
+## Related Issues
+<!-- Link any related issues here (e.g., Fixes #123) -->
+
+## Type of Change
+- [ ] Bug fix (non-breaking change that fixes an issue)
+- [ ] New feature (non-breaking change that adds functionality)
+- [ ] Breaking change (fix or feature that would cause existing functionality to change)
+- [ ] Documentation update
+- [ ] Refactoring (no functional changes)
+
+## How Has This Been Tested?
+<!-- Describe the tests you ran to verify your changes -->
+
+## Checklist:
+- [ ] My code follows the code style of this project
+- [ ] I have updated the documentation accordingly
+- [ ] I have added tests to cover my changes
+- [ ] All new and existing tests passed
+- [ ] I have checked for potential performance impacts
+- [ ] I have considered security implications
+
+## Screenshots (if applicable):
+<!-- Add screenshots here if applicable -->


### PR DESCRIPTION
fixes #1 
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add GitHub templates for bug reports, feature requests, and pull requests to standardize contributions.
> 
>   - **GitHub Templates**:
>     - Adds `bug_report.md` for reporting bugs with sections for description, reproduction steps, expected and actual behavior, environment, and additional context.
>     - Adds `feature_request.md` for suggesting features with sections for description, problem statement, proposed solution, alternatives, and additional context.
>     - Adds `PULL_REQUEST_TEMPLATE.md` for pull requests with sections for description, related issues, type of change, testing, checklist, and screenshots.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=trainjumpers%2Fexpenses&utm_source=github&utm_medium=referral)<sup> for 0c5b55fd0f7bcfacb3084dd3cdcb2924f25b5ce6. You can [customize](https://app.ellipsis.dev/trainjumpers/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->