### PR TITLE
fix: pretty print the error

### DIFF
--- a/server/internal/api/controller/common.go
+++ b/server/internal/api/controller/common.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	customErrors "expenses/internal/errors"
 	"net/http"
+	"strings"
 
 	"github.com/gin-gonic/gin"
 )
@@ -20,7 +21,17 @@ func handleError(ctx *gin.Context, stack bool, err error) {
 		}
 		if stack {
 			response["error"] = authErr.Err.Error()
-			response["stack"] = authErr.Stack
+			if authErr.Stack != "" {
+				stackLines := strings.Split(authErr.Stack, "\n")
+				nonEmptyLines := make([]string, 0, len(stackLines))
+				for _, line := range stackLines {
+					line = strings.ReplaceAll(line, "\t", "")
+					if line != "" {
+						nonEmptyLines = append(nonEmptyLines, line)
+					}
+				}
+				response["stack"] = nonEmptyLines
+			}
 		}
 		ctx.JSON(authErr.Status, response)
 		return

--- a/server/internal/api/controller/common.go
+++ b/server/internal/api/controller/common.go
@@ -13,7 +13,7 @@ import (
 // trimming whitespace, and removing empty lines
 func cleanStackTrace(stack string) []string {
 	if stack == "" {
-		return nil
+		return []string{}
 	}
 
 	stackLines := strings.Split(stack, "\n")

--- a/server/internal/api/controller/common.go
+++ b/server/internal/api/controller/common.go
@@ -9,6 +9,24 @@ import (
 	"github.com/gin-gonic/gin"
 )
 
+// cleanStackTrace processes a stack trace string by splitting it into lines,
+// trimming whitespace, and removing empty lines
+func cleanStackTrace(stack string) []string {
+	if stack == "" {
+		return nil
+	}
+
+	stackLines := strings.Split(stack, "\n")
+	nonEmptyLines := make([]string, 0, len(stackLines))
+	for _, line := range stackLines {
+		line = strings.TrimSpace(line)
+		if line != "" {
+			nonEmptyLines = append(nonEmptyLines, line)
+		}
+	}
+	return nonEmptyLines
+}
+
 func handleError(ctx *gin.Context, stack bool, err error) {
 	if err == nil {
 		return
@@ -21,17 +39,7 @@ func handleError(ctx *gin.Context, stack bool, err error) {
 		}
 		if stack {
 			response["error"] = authErr.Err.Error()
-			if authErr.Stack != "" {
-				stackLines := strings.Split(authErr.Stack, "\n")
-				nonEmptyLines := make([]string, 0, len(stackLines))
-				for _, line := range stackLines {
-					line = strings.ReplaceAll(line, "\t", "")
-					if line != "" {
-						nonEmptyLines = append(nonEmptyLines, line)
-					}
-				}
-				response["stack"] = nonEmptyLines
-			}
+			response["stack"] = cleanStackTrace(authErr.Stack)
 		}
 		ctx.JSON(authErr.Status, response)
 		return


### PR DESCRIPTION
## Description
The stack trace returned is difficult to read. Pretty print it


<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Adds `cleanStackTrace` to format stack traces in `common.go` and updates `handleError` to use it.
> 
>   - **Functionality**:
>     - Adds `cleanStackTrace` function in `common.go` to format stack traces by removing empty lines and trimming whitespace.
>     - Updates `handleError` in `common.go` to use `cleanStackTrace` for processing stack traces before adding them to the response.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=trainjumpers%2Fexpenses&utm_source=github&utm_medium=referral)<sup> for c22f82346e218fa9fe6806e7ccd98b4ef131e0e9. You can [customize](https://app.ellipsis.dev/trainjumpers/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->