### PR TITLE
fix: actually return no content for no content

### DIFF
--- a/server/internal/api/controller/base_controller.go
+++ b/server/internal/api/controller/base_controller.go
@@ -56,6 +56,10 @@ func (b *BaseController) HandleError(ctx *gin.Context, err error) {
 
 // SendSuccess sends a successful response with optional data
 func (b *BaseController) SendSuccess(ctx *gin.Context, statusCode int, message string, data interface{}) {
+	if statusCode == http.StatusNoContent {
+		ctx.Status(http.StatusNoContent)
+		return
+	}
 	response := gin.H{
 		"message": message,
 	}

--- a/server/internal/api/controller/base_controller.go
+++ b/server/internal/api/controller/base_controller.go
@@ -54,7 +54,7 @@ func (b *BaseController) HandleError(ctx *gin.Context, err error) {
 	ctx.JSON(http.StatusInternalServerError, response)
 }
 
-// SendSuccess sends a successful response with optional data
+// SendSuccess sends a successful response with optional data. Note: when statusCode is 204, the message and data parameters are ignored.
 func (b *BaseController) SendSuccess(ctx *gin.Context, statusCode int, message string, data interface{}) {
 	if statusCode == http.StatusNoContent {
 		ctx.Status(http.StatusNoContent)


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> `SendSuccess()` in `BaseController` now correctly handles `http.StatusNoContent` by sending only the status without a JSON body.
> 
>   - **Behavior**:
>     - In `BaseController`, `SendSuccess()` now correctly handles `http.StatusNoContent` by sending only the status without a JSON body.
>   - **Misc**:
>     - No changes to other methods or files.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=trainjumpers%2Fexpenses&utm_source=github&utm_medium=referral)<sup> for 716eff37562b7cc0f55fab9b51f2d6097d032be6. You can [customize](https://app.ellipsis.dev/trainjumpers/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->