### PR TITLE
feat: add a middleware to inject createdBy automatically

### DIFF
--- a/server/internal/api/controller/account_controller.go
+++ b/server/internal/api/controller/account_controller.go
@@ -24,13 +24,12 @@ func NewAccountController(cfg *config.Config, accountService service.AccountServ
 }
 
 func (a *AccountController) CreateAccount(ctx *gin.Context) {
-	logger.Infof("Creating new account for user %d", a.GetAuthenticatedUserId(ctx))
 	var input models.CreateAccountInput
 	if err := a.BindJSON(ctx, &input); err != nil {
 		logger.Errorf("Failed to bind JSON: %v", err)
 		return
 	}
-	input.CreatedBy = a.GetAuthenticatedUserId(ctx)
+	logger.Infof("Creating new account for user %d", input.CreatedBy)
 	account, err := a.accountService.CreateAccount(ctx, input)
 	if err != nil {
 		logger.Errorf("Error creating account: %v", err)

--- a/server/internal/api/controller/category_controller.go
+++ b/server/internal/api/controller/category_controller.go
@@ -24,13 +24,12 @@ func NewCategoryController(cfg *config.Config, categoryService service.CategoryS
 }
 
 func (c *CategoryController) CreateCategory(ctx *gin.Context) {
-	logger.Infof("Creating new category for user %d", c.GetAuthenticatedUserId(ctx))
 	var input models.CreateCategoryInput
 	if err := c.BindJSON(ctx, &input); err != nil {
 		logger.Errorf("Failed to bind JSON: %v", err)
 		return
 	}
-	input.CreatedBy = c.GetAuthenticatedUserId(ctx)
+	logger.Infof("Creating new category for user %d", input.CreatedBy)
 	category, err := c.categoryService.CreateCategory(ctx, input)
 	if err != nil {
 		logger.Errorf("Error creating category: %v", err)

--- a/server/internal/api/controller/transaction_controller.go
+++ b/server/internal/api/controller/transaction_controller.go
@@ -25,15 +25,12 @@ func NewTransactionController(cfg *config.Config, transactionService service.Tra
 }
 
 func (t *TransactionController) CreateTransaction(ctx *gin.Context) {
-	userId := t.GetAuthenticatedUserId(ctx)
-	logger.Infof("Creating new transaction for user %d", userId)
-
 	var input models.CreateTransactionInput
 	if err := t.BindJSON(ctx, &input); err != nil {
 		logger.Errorf("Failed to bind JSON: %v", err)
 		return
 	}
-	input.CreatedBy = userId
+	logger.Infof("Creating new transaction for user %d", input.CreatedBy)
 	transaction, err := t.transactionService.CreateTransaction(ctx, input)
 	if err != nil {
 		logger.Errorf("Error creating transaction: %v", err)
@@ -41,7 +38,7 @@ func (t *TransactionController) CreateTransaction(ctx *gin.Context) {
 		return
 	}
 
-	logger.Infof("Transaction created successfully with ID %d for user %d", transaction.Id, userId)
+	logger.Infof("Transaction created successfully with ID %d for user %d", transaction.Id, transaction.CreatedBy)
 	t.SendSuccess(ctx, http.StatusCreated, "Transaction created successfully", transaction)
 }
 

--- a/server/internal/api/middleware/helpers.go
+++ b/server/internal/api/middleware/helpers.go
@@ -1,0 +1,16 @@
+package middleware
+
+import (
+	"expenses/internal/config"
+
+	"github.com/gin-gonic/gin"
+)
+
+// ProtectedWithCreatedBy returns a slice of middleware that applies both
+// authentication and created_by injection. Use with route groups to avoid repetition.
+func ProtectedWithCreatedBy(cfg *config.Config) []gin.HandlerFunc {
+	return []gin.HandlerFunc{
+		Protected(cfg),
+		InjectCreatedBy(),
+	}
+}

--- a/server/internal/api/routes.go
+++ b/server/internal/api/routes.go
@@ -60,37 +60,37 @@ func Init(
 		base.POST("/refresh", authController.RefreshToken)
 
 		// User related routes
-		user := base.Group("/user").Use(gin.HandlerFunc(middleware.Protected(cfg))).Use(gin.HandlerFunc(middleware.InjectCreatedBy()))
+		user := base.Group("/user", middleware.ProtectedWithCreatedBy(cfg)...)
 		{
 			user.GET("", userController.GetUserById)
 			user.DELETE("", userController.DeleteUser)
 			user.PATCH("", userController.UpdateUser)
 			user.POST("/password", userController.UpdateUserPassword)
-
-			// Account routes
-			account := base.Group("/account").Use(gin.HandlerFunc(middleware.Protected(cfg))).Use(gin.HandlerFunc(middleware.InjectCreatedBy()))
-			account.GET("", accountController.ListAccounts)
-			account.POST("", accountController.CreateAccount)
-			account.GET("/:accountId", accountController.GetAccount)
-			account.PATCH("/:accountId", accountController.UpdateAccount)
-			account.DELETE("/:accountId", accountController.DeleteAccount)
-
-			// Category routes
-			category := base.Group("/category").Use(gin.HandlerFunc(middleware.Protected(cfg))).Use(gin.HandlerFunc(middleware.InjectCreatedBy()))
-			category.GET("", categoryController.ListCategories)
-			category.POST("", categoryController.CreateCategory)
-			category.GET("/:categoryId", categoryController.GetCategory)
-			category.PATCH("/:categoryId", categoryController.UpdateCategory)
-			category.DELETE("/:categoryId", categoryController.DeleteCategory)
-
-			// Transaction routes
-			transaction := base.Group("/transaction").Use(gin.HandlerFunc(middleware.Protected(cfg))).Use(gin.HandlerFunc(middleware.InjectCreatedBy()))
-			transaction.GET("", transactionController.ListTransactions)
-			transaction.POST("", transactionController.CreateTransaction)
-			transaction.GET("/:transactionId", transactionController.GetTransaction)
-			transaction.PATCH("/:transactionId", transactionController.UpdateTransaction)
-			transaction.DELETE("/:transactionId", transactionController.DeleteTransaction)
 		}
+
+		// Account routes
+		account := base.Group("/account", middleware.ProtectedWithCreatedBy(cfg)...)
+		account.GET("", accountController.ListAccounts)
+		account.POST("", accountController.CreateAccount)
+		account.GET("/:accountId", accountController.GetAccount)
+		account.PATCH("/:accountId", accountController.UpdateAccount)
+		account.DELETE("/:accountId", accountController.DeleteAccount)
+
+		// Category routes
+		category := base.Group("/category", middleware.ProtectedWithCreatedBy(cfg)...)
+		category.GET("", categoryController.ListCategories)
+		category.POST("", categoryController.CreateCategory)
+		category.GET("/:categoryId", categoryController.GetCategory)
+		category.PATCH("/:categoryId", categoryController.UpdateCategory)
+		category.DELETE("/:categoryId", categoryController.DeleteCategory)
+
+		// Transaction routes
+		transaction := base.Group("/transaction", middleware.ProtectedWithCreatedBy(cfg)...)
+		transaction.GET("", transactionController.ListTransactions)
+		transaction.POST("", transactionController.CreateTransaction)
+		transaction.GET("/:transactionId", transactionController.GetTransaction)
+		transaction.PATCH("/:transactionId", transactionController.UpdateTransaction)
+		transaction.DELETE("/:transactionId", transactionController.DeleteTransaction)
 	}
 
 	return router

--- a/server/internal/api/routes.go
+++ b/server/internal/api/routes.go
@@ -60,7 +60,7 @@ func Init(
 		base.POST("/refresh", authController.RefreshToken)
 
 		// User related routes
-		user := base.Group("/user").Use(gin.HandlerFunc(middleware.Protected(cfg)))
+		user := base.Group("/user").Use(gin.HandlerFunc(middleware.Protected(cfg))).Use(gin.HandlerFunc(middleware.InjectCreatedBy()))
 		{
 			user.GET("", userController.GetUserById)
 			user.DELETE("", userController.DeleteUser)
@@ -68,7 +68,7 @@ func Init(
 			user.POST("/password", userController.UpdateUserPassword)
 
 			// Account routes
-			account := base.Group("/account").Use(gin.HandlerFunc(middleware.Protected(cfg)))
+			account := base.Group("/account").Use(gin.HandlerFunc(middleware.Protected(cfg))).Use(gin.HandlerFunc(middleware.InjectCreatedBy()))
 			account.GET("", accountController.ListAccounts)
 			account.POST("", accountController.CreateAccount)
 			account.GET("/:accountId", accountController.GetAccount)
@@ -76,7 +76,7 @@ func Init(
 			account.DELETE("/:accountId", accountController.DeleteAccount)
 
 			// Category routes
-			category := base.Group("/category").Use(gin.HandlerFunc(middleware.Protected(cfg)))
+			category := base.Group("/category").Use(gin.HandlerFunc(middleware.Protected(cfg))).Use(gin.HandlerFunc(middleware.InjectCreatedBy()))
 			category.GET("", categoryController.ListCategories)
 			category.POST("", categoryController.CreateCategory)
 			category.GET("/:categoryId", categoryController.GetCategory)
@@ -84,7 +84,7 @@ func Init(
 			category.DELETE("/:categoryId", categoryController.DeleteCategory)
 
 			// Transaction routes
-			transaction := base.Group("/transaction").Use(gin.HandlerFunc(middleware.Protected(cfg)))
+			transaction := base.Group("/transaction").Use(gin.HandlerFunc(middleware.Protected(cfg))).Use(gin.HandlerFunc(middleware.InjectCreatedBy()))
 			transaction.GET("", transactionController.ListTransactions)
 			transaction.POST("", transactionController.CreateTransaction)
 			transaction.GET("/:transactionId", transactionController.GetTransaction)

--- a/server/internal/models/account.go
+++ b/server/internal/models/account.go
@@ -20,7 +20,7 @@ type CreateAccountInput struct {
 	BankType  BankType `json:"bank_type" binding:"required,oneof=investment axis sbi hdfc icici"`
 	Currency  string   `json:"currency" binding:"required,oneof=inr usd"`
 	Balance   *float64 `json:"balance"`
-	CreatedBy int64    `json:"created_by"`
+	CreatedBy int64    `json:"created_by" binding:"required"`
 }
 
 type UpdateAccountInput struct {

--- a/server/internal/models/category.go
+++ b/server/internal/models/category.go
@@ -4,7 +4,7 @@ package models
 type CreateCategoryInput struct {
 	Name      string `json:"name" binding:"required" maxlength:"100"`
 	Icon      string `json:"icon"`
-	CreatedBy int64  `json:"created_by"`
+	CreatedBy int64  `json:"created_by" binding:"required"`
 }
 
 // UpdateCategoryInput is used for updating an existing category

--- a/server/internal/models/transaction.go
+++ b/server/internal/models/transaction.go
@@ -10,7 +10,7 @@ type CreateBaseTransactionInput struct {
 	Description string    `json:"description" binding:"max=1000"`
 	Amount      *float64  `json:"amount" binding:"required"`
 	Date        time.Time `json:"date" binding:"required"`
-	CreatedBy   int64     `json:"created_by"`
+	CreatedBy   int64     `json:"created_by" binding:"required"`
 	AccountId   int64     `json:"account_id" binding:"required"`
 }
 


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Introduces middleware to automatically inject `created_by` field into request bodies, updating routes and models accordingly.
> 
>   - **Middleware**:
>     - Adds `InjectCreatedBy` middleware in `auth.go` to inject `created_by` field for POST/PUT/PATCH requests.
>     - Adds `ProtectedWithCreatedBy` in `helpers.go` to combine authentication and `created_by` injection.
>   - **Routes**:
>     - Updates `routes.go` to use `ProtectedWithCreatedBy` for user, account, category, and transaction routes.
>   - **Controllers**:
>     - Removes manual `created_by` assignment in `CreateAccount`, `CreateCategory`, and `CreateTransaction` methods.
>   - **Models**:
>     - Updates `CreateAccountInput`, `CreateCategoryInput`, and `CreateBaseTransactionInput` to require `created_by` field.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=trainjumpers%2Fexpenses&utm_source=github&utm_medium=referral)<sup> for c094dd8f923e36629800243d0cbc1f0fc848d447. You can [customize](https://app.ellipsis.dev/trainjumpers/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->