### PR TITLE
fix: improve login perf

### DIFF
--- a/server/internal/database/seed/test/00001_users.sql
+++ b/server/internal/database/seed/test/00001_users.sql
@@ -1,8 +1,8 @@
 -- +goose Up
 -- +goose StatementBegin
-INSERT INTO test.user (name, email, password, created_at, updated_at) VALUES ('Test user 1', 'test1@example.com', '$2a$14$N13BsEF2NyxT3qUlFIzmLujxCJcjjdf40PS2Gtcyl.ToGBazk0YVe', NOW(), NOW());
-INSERT INTO test.user (name, email, password, created_at, updated_at) VALUES ('Test user 2', 'test2@example.com', '$2a$14$N13BsEF2NyxT3qUlFIzmLujxCJcjjdf40PS2Gtcyl.ToGBazk0YVe', NOW(), NOW());
-INSERT INTO test.user (name, email, password, created_at, updated_at) VALUES ('Test user 3', 'test3@example.com', '$2a$14$N13BsEF2NyxT3qUlFIzmLujxCJcjjdf40PS2Gtcyl.ToGBazk0YVe', NOW(), NOW());
+INSERT INTO test.user (name, email, password, created_at, updated_at) VALUES ('Test user 1', 'test1@example.com', '$2a$10$.gzt.JGLbMl01.KnwoRvyuPAt0h.XtRuKTnaAmUPXF6r5P.8XP3kO', NOW(), NOW());
+INSERT INTO test.user (name, email, password, created_at, updated_at) VALUES ('Test user 2', 'test2@example.com', '$2a$10$.gzt.JGLbMl01.KnwoRvyuPAt0h.XtRuKTnaAmUPXF6r5P.8XP3kO', NOW(), NOW());
+INSERT INTO test.user (name, email, password, created_at, updated_at) VALUES ('Test user 3', 'test3@example.com', '$2a$10$.gzt.JGLbMl01.KnwoRvyuPAt0h.XtRuKTnaAmUPXF6r5P.8XP3kO', NOW(), NOW());
 -- +goose StatementEnd
 
 -- +goose Down

--- a/server/internal/service/auth_service.go
+++ b/server/internal/service/auth_service.go
@@ -218,7 +218,7 @@ func (a *AuthService) issueAuthToken(userId int64, email string) (string, error)
 }
 
 func (a *AuthService) hashPassword(password string) (string, error) {
-	bytes, err := bcrypt.GenerateFromPassword([]byte(password), 14)
+	bytes, err := bcrypt.GenerateFromPassword([]byte(password), 10)
 	return string(bytes), err
 }
 


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Reduce bcrypt hashing cost factor from 14 to 10 to improve login performance.
> 
>   - **Performance Improvement**:
>     - Reduce bcrypt hashing cost factor from 14 to 10 in `hashPassword()` in `auth_service.go`.
>     - Update test user passwords in `00001_users.sql` to reflect new bcrypt cost factor.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=trainjumpers%2Fexpenses&utm_source=github&utm_medium=referral)<sup> for c8cd03fd61bbed0b2d39ff231eae08be19500568. You can [customize](https://app.ellipsis.dev/trainjumpers/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->