### PR TITLE
feat: introduce custom parser for any type of CSV

### DIFF
--- a/frontend/components/custom/Modal/Statement/ImportStatementModal.tsx
+++ b/frontend/components/custom/Modal/Statement/ImportStatementModal.tsx
@@ -1,30 +1,30 @@
 import { useAccounts } from "@/components/hooks/useAccounts";
-import { useUploadStatement } from "@/components/hooks/useStatements";
-import { LoadingButton } from "@/components/ui/LoadingButton";
-import { Button } from "@/components/ui/button";
+import {
+  usePreviewStatement,
+  useUploadStatement,
+} from "@/components/hooks/useStatements";
 import {
   Dialog,
   DialogContent,
-  DialogFooter,
   DialogHeader,
   DialogTitle,
 } from "@/components/ui/dialog";
-import {
-  DropdownMenu,
-  DropdownMenuContent,
-  DropdownMenuItem,
-  DropdownMenuTrigger,
-} from "@/components/ui/dropdown-menu";
-import { Input } from "@/components/ui/input";
-import { Label } from "@/components/ui/label";
-import {
-  AlertCircle,
-  ChevronDownIcon,
-  FileText,
-  Upload,
-  X,
-} from "lucide-react";
+import { StatementPreviewResponse } from "@/lib/models/statement";
 import { useCallback, useState } from "react";
+
+import { FallbackParsing } from "./steps/FallbackParsing";
+import { ImportFromBank } from "./steps/ImportFromBank";
+import { MapColumns } from "./steps/MapColumns";
+import { SelectBank } from "./steps/SelectBank";
+
+// Constants
+const PREVIEW_SIZE = 5;
+enum ImportStep {
+  SelectBank = 1,
+  ImportFromBank = 2,
+  Preview = 3,
+  MapColumns = 4,
+}
 
 interface ImportStatementModalProps {
   isOpen: boolean;
@@ -37,50 +37,60 @@ export function ImportStatementModal({
 }: ImportStatementModalProps) {
   const { data: accounts = [] } = useAccounts();
   const uploadStatementMutation = useUploadStatement();
+  const previewStatementMutation = usePreviewStatement();
 
+  const [step, setStep] = useState<ImportStep>(ImportStep.SelectBank);
   const [selectedFile, setSelectedFile] = useState<File | null>(null);
+  const [skipRows, setSkipRows] = useState(0);
+  const [rowSize, setRowSize] = useState(PREVIEW_SIZE);
+  const [previewData, setPreviewData] =
+    useState<StatementPreviewResponse | null>(null);
   const [selectedAccountId, setSelectedAccountId] = useState<number>(
     accounts[0]?.id || 0
   );
   const [dragActive, setDragActive] = useState(false);
   const [error, setError] = useState<string>("");
 
-  const validateFile = (file: File): string | null => {
-    // Check file size (256KB)
+  const validateFile = (file: File, forBank: boolean): string | null => {
     if (file.size > 256 * 1024) {
       return "File size must be less than 256KB";
     }
-
-    // Check file type
-    const validTypes = [
-      "text/csv",
-      "application/vnd.ms-excel",
-      "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
-    ];
-    const validExtensions = [".csv", ".xls", ".xlsx"];
-
-    const isValidType =
-      validTypes.includes(file.type) ||
-      validExtensions.some((ext) => file.name.toLowerCase().endsWith(ext));
-
-    if (!isValidType) {
-      return "File must be CSV or Excel format (.csv, .xls, .xlsx)";
+    const validExtensions = forBank
+      ? [".csv", ".xls", ".xlsx"]
+      : [".csv", ".xls"];
+    if (!validExtensions.some((ext) => file.name.toLowerCase().endsWith(ext))) {
+      return `File must be ${validExtensions.join(", ")} format`;
     }
-
     return null;
   };
 
-  const handleFileSelect = (file: File) => {
-    const validationError = validateFile(file);
-    if (validationError) {
-      setError(validationError);
-      setSelectedFile(null);
-      return;
-    }
+  const handleFileSelect = useCallback(
+    (file: File) => {
+      const validationError = validateFile(
+        file,
+        step === ImportStep.ImportFromBank
+      );
+      if (validationError) {
+        setError(validationError);
+        setSelectedFile(null);
+        setPreviewData(null);
+        return;
+      }
 
-    setError("");
-    setSelectedFile(file);
-  };
+      setError("");
+      setSelectedFile(file);
+      if (step === ImportStep.Preview) {
+        previewStatementMutation.mutate(
+          { file, skipRows, rowSize },
+          {
+            onSuccess: (data) => setPreviewData(data),
+            onError: () => setPreviewData(null),
+          }
+        );
+      }
+    },
+    [step, skipRows, rowSize, previewStatementMutation]
+  );
 
   const handleFileInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const file = e.target.files?.[0];
@@ -99,42 +109,93 @@ export function ImportStatementModal({
     }
   }, []);
 
-  const handleDrop = useCallback((e: React.DragEvent) => {
-    e.preventDefault();
-    e.stopPropagation();
-    setDragActive(false);
-
-    const file = e.dataTransfer.files?.[0];
-    if (file) {
-      const validationError = validateFile(file);
-      if (validationError) {
-        setError(validationError);
-        setSelectedFile(null);
-        return;
+  const handleDrop = useCallback(
+    (e: React.DragEvent) => {
+      e.preventDefault();
+      e.stopPropagation();
+      setDragActive(false);
+      const file = e.dataTransfer.files?.[0];
+      if (file) {
+        handleFileSelect(file);
       }
+    },
+    [handleFileSelect]
+  );
 
-      setError("");
-      setSelectedFile(file);
+  const handleSkipRowsChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const value = parseInt(e.target.value, 10);
+    setSkipRows(value);
+    if (selectedFile) {
+      previewStatementMutation.mutate(
+        { file: selectedFile, skipRows: value, rowSize },
+        {
+          onSuccess: (data) => setPreviewData(data),
+          onError: () => setPreviewData(null),
+        }
+      );
     }
-  }, []);
+  };
+
+  const handleRowSizeChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const value = parseInt(e.target.value, PREVIEW_SIZE);
+    setRowSize(isNaN(value) ? PREVIEW_SIZE : value);
+    if (selectedFile) {
+      previewStatementMutation.mutate(
+        { file: selectedFile, skipRows, rowSize: value },
+        {
+          onSuccess: (data) => setPreviewData(data),
+          onError: () => setPreviewData(null),
+        }
+      );
+    }
+  };
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
+    if (!selectedFile || !selectedAccountId) {
+      setError("Please select a file and an account");
+      return;
+    }
+    uploadStatementMutation.mutate(
+      { account_id: selectedAccountId, file: selectedFile },
+      { onSuccess: () => handleCancel() }
+    );
+  };
 
+  const handleCancel = () => {
+    setSelectedFile(null);
+    setSelectedAccountId(accounts[0]?.id || 0);
+    setError("");
+    setStep(ImportStep.SelectBank);
+    setPreviewData(null);
+    setSkipRows(0);
+    setRowSize(PREVIEW_SIZE);
+    onOpenChange(false);
+  };
+
+  const removeFile = () => {
+    setSelectedFile(null);
+    setError("");
+    setPreviewData(null);
+  };
+
+  const handleProcessStatement = (mappings: Record<string, string>) => {
     if (!selectedFile) {
-      setError("Please select a file");
+      setError("Something went wrong, no file selected.");
       return;
     }
 
-    if (!selectedAccountId) {
-      setError("Please select an account");
-      return;
-    }
+    const metadata = {
+      skipRows: skipRows,
+      columnMapping: mappings,
+    };
 
     uploadStatementMutation.mutate(
       {
         account_id: selectedAccountId,
         file: selectedFile,
+        bank_type: "others",
+        metadata: JSON.stringify(metadata),
       },
       {
         onSuccess: () => {
@@ -144,179 +205,83 @@ export function ImportStatementModal({
     );
   };
 
-  const handleCancel = () => {
-    setSelectedFile(null);
-    setSelectedAccountId(accounts[0]?.id || 0);
-    setError("");
-    onOpenChange(false);
+  const renderStep = () => {
+    switch (step) {
+      case ImportStep.ImportFromBank:
+        return (
+          <ImportFromBank
+            accounts={accounts}
+            selectedAccountId={selectedAccountId}
+            onSelectedAccountIdChange={setSelectedAccountId}
+            selectedFile={selectedFile}
+            onFileInputChange={handleFileInputChange}
+            onFileRemove={removeFile}
+            error={error}
+            dragActive={dragActive}
+            handleDrag={handleDrag}
+            handleDrop={handleDrop}
+            handleSubmit={handleSubmit}
+            onStepChange={setStep}
+            uploadStatementMutation={uploadStatementMutation}
+          />
+        );
+      case ImportStep.Preview:
+        return (
+          <FallbackParsing
+            accounts={accounts}
+            selectedAccountId={selectedAccountId}
+            onSelectedAccountIdChange={setSelectedAccountId}
+            selectedFile={selectedFile}
+            onFileInputChange={handleFileInputChange}
+            onFileRemove={removeFile}
+            error={error}
+            dragActive={dragActive}
+            handleDrag={handleDrag}
+            handleDrop={handleDrop}
+            skipRows={skipRows}
+            onSkipRowsChange={handleSkipRowsChange}
+            rowSize={rowSize}
+            onRowSizeChange={handleRowSizeChange}
+            previewData={previewData}
+            previewStatementMutation={previewStatementMutation}
+            onStepChange={setStep}
+          />
+        );
+      case ImportStep.MapColumns:
+        return (
+          <MapColumns
+            headers={previewData?.headers || []}
+            onStepChange={setStep}
+            onCancel={handleCancel}
+            onSubmit={handleProcessStatement}
+          />
+        );
+      default:
+        return <SelectBank onStepChange={setStep} />;
+    }
   };
 
-  const removeFile = () => {
-    setSelectedFile(null);
-    setError("");
+  const getTitle = () => {
+    switch (step) {
+      case ImportStep.ImportFromBank:
+        return "Import from Bank";
+      case ImportStep.Preview:
+        return "Preview";
+      case ImportStep.MapColumns:
+        return "Map Columns";
+      default:
+        return "Select Import Method";
+    }
   };
 
   return (
-    <>
-      <Dialog open={isOpen} onOpenChange={onOpenChange}>
-        <DialogContent className="sm:max-w-[500px]">
-          <DialogHeader>
-            <DialogTitle>Import Bank Statement</DialogTitle>
-          </DialogHeader>
-
-          <form onSubmit={handleSubmit}>
-            <div className="space-y-6 py-4">
-              {/* Account Selection */}
-              <div className="space-y-2">
-                <Label>Account</Label>
-                <DropdownMenu>
-                  <DropdownMenuTrigger asChild>
-                    <Button
-                      variant="outline"
-                      className="w-full justify-start text-left font-normal flex items-center"
-                      type="button"
-                    >
-                      {(() => {
-                        const selected = accounts.find(
-                          (acc) => acc.id === selectedAccountId
-                        );
-                        return selected
-                          ? `${selected.name} (${selected.bank_type.toUpperCase()})`
-                          : "Select account";
-                      })()}
-                      <ChevronDownIcon className="ml-auto w-4 h-4 opacity-60" />
-                    </Button>
-                  </DropdownMenuTrigger>
-                  <DropdownMenuContent className="w-56 max-h-64 overflow-y-auto">
-                    {accounts.map((account) => (
-                      <DropdownMenuItem
-                        key={account.id}
-                        onClick={() => setSelectedAccountId(account.id)}
-                        className={`py-1 px-2 text-sm min-h-0 h-8 cursor-pointer flex items-center ${
-                          selectedAccountId === account.id
-                            ? "bg-accent/40 font-semibold"
-                            : ""
-                        }`}
-                      >
-                        {account.name} ({account.bank_type.toUpperCase()})
-                      </DropdownMenuItem>
-                    ))}
-                  </DropdownMenuContent>
-                </DropdownMenu>
-              </div>
-
-              {/* File Upload */}
-              <div className="space-y-2">
-                <Label>Statement File</Label>
-                <div className="space-y-4">
-                  {!selectedFile ? (
-                    <div
-                      onDragEnter={handleDrag}
-                      onDragLeave={handleDrag}
-                      onDragOver={handleDrag}
-                      onDrop={handleDrop}
-                      className={`border-2 border-dashed rounded-lg p-6 text-center cursor-pointer transition-colors ${
-                        dragActive
-                          ? "border-primary bg-primary/5"
-                          : "border-border hover:border-primary dark:border-border dark:hover:border-primary"
-                      }`}
-                      onClick={() =>
-                        document.getElementById("file-input")?.click()
-                      }
-                    >
-                      <Upload className="mx-auto h-12 w-12 text-muted-foreground mb-4" />
-                      <p className="text-sm text-foreground mb-2">
-                        {dragActive
-                          ? "Drop the file here..."
-                          : "Drag & drop your bank statement here, or click to select"}
-                      </p>
-                      <p className="text-xs text-muted-foreground">
-                        Supports CSV, XLS, XLSX files (max 256KB)
-                      </p>
-                      <Input
-                        id="file-input"
-                        type="file"
-                        accept=".csv,.xls,.xlsx"
-                        onChange={handleFileInputChange}
-                        className="hidden"
-                      />
-                    </div>
-                  ) : (
-                    <div className="border rounded-lg p-4 bg-muted/50 dark:bg-muted/20">
-                      <div className="flex items-center justify-between">
-                        <div className="flex items-center space-x-3">
-                          <FileText className="h-8 w-8 text-blue-500 dark:text-blue-400" />
-                          <div>
-                            <p className="text-sm font-medium text-foreground">
-                              {selectedFile.name}
-                            </p>
-                            <p className="text-xs text-muted-foreground">
-                              {(selectedFile.size / 1024).toFixed(1)} KB
-                            </p>
-                          </div>
-                        </div>
-                        <Button
-                          type="button"
-                          variant="outline"
-                          size="sm"
-                          onClick={removeFile}
-                        >
-                          <X className="h-4 w-4" />
-                        </Button>
-                      </div>
-                    </div>
-                  )}
-
-                  {/* Error Display */}
-                  {error && (
-                    <div className="text-sm text-destructive flex items-center space-x-2">
-                      <AlertCircle className="h-4 w-4" />
-                      <span>{error}</span>
-                    </div>
-                  )}
-                </div>
-              </div>
-
-              <div className="bg-blue-50 dark:bg-blue-950/50 border border-blue-200 dark:border-blue-800 rounded-lg p-4">
-                <div className="flex items-start space-x-3">
-                  <AlertCircle className="h-5 w-5 text-blue-500 dark:text-blue-400 mt-0.5" />
-                  <div className="text-sm text-blue-700 dark:text-blue-300">
-                    <p className="font-medium mb-1">Processing Information:</p>
-                    <ul className="text-xs space-y-1 text-blue-600 dark:text-blue-400">
-                      <li>
-                        • Your statement will be processed in the background
-                      </li>
-                      <li>
-                        • You can check the processing status in the statements
-                        history
-                      </li>
-                    </ul>
-                  </div>
-                </div>
-              </div>
-            </div>
-
-            <DialogFooter>
-              <Button
-                type="button"
-                variant="outline"
-                onClick={handleCancel}
-                disabled={uploadStatementMutation.isPending}
-              >
-                Cancel
-              </Button>
-              <LoadingButton
-                type="submit"
-                loading={uploadStatementMutation.isPending}
-                disabled={uploadStatementMutation.isPending || !selectedFile}
-                fixedWidth="140px"
-              >
-                Import Statement
-              </LoadingButton>
-            </DialogFooter>
-          </form>
-        </DialogContent>
-      </Dialog>
-    </>
+    <Dialog open={isOpen} onOpenChange={handleCancel}>
+      <DialogContent className="sm:max-w-lg">
+        <DialogHeader>
+          <DialogTitle>{getTitle()}</DialogTitle>
+        </DialogHeader>
+        {renderStep()}
+      </DialogContent>
+    </Dialog>
   );
 }

--- a/frontend/components/custom/Modal/Statement/steps/FallbackParsing.tsx
+++ b/frontend/components/custom/Modal/Statement/steps/FallbackParsing.tsx
@@ -1,0 +1,284 @@
+import { Button } from "@/components/ui/button";
+import { DialogFooter } from "@/components/ui/dialog";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
+import { Account } from "@/lib/models/account";
+import { StatementPreviewResponse } from "@/lib/models/statement";
+import { UseMutationResult } from "@tanstack/react-query";
+import {
+  AlertCircle,
+  ChevronDownIcon,
+  FileText,
+  Upload,
+  X,
+} from "lucide-react";
+
+interface FallbackParsingProps {
+  accounts: Account[];
+  selectedAccountId: number;
+  onSelectedAccountIdChange: (id: number) => void;
+  selectedFile: File | null;
+  onFileInputChange: (e: React.ChangeEvent<HTMLInputElement>) => void;
+  onFileRemove: () => void;
+  error: string;
+  dragActive: boolean;
+  handleDrag: (e: React.DragEvent) => void;
+  handleDrop: (e: React.DragEvent) => void;
+  skipRows: number;
+  onSkipRowsChange: (e: React.ChangeEvent<HTMLInputElement>) => void;
+  rowSize: number;
+  onRowSizeChange: (e: React.ChangeEvent<HTMLInputElement>) => void;
+  previewData: StatementPreviewResponse | null;
+  previewStatementMutation: UseMutationResult<
+    StatementPreviewResponse,
+    Error,
+    { file: File; skipRows: number; rowSize: number }
+  >;
+  onStepChange: (step: number) => void;
+}
+
+export function FallbackParsing({
+  accounts,
+  selectedAccountId,
+  onSelectedAccountIdChange,
+  selectedFile,
+  onFileInputChange,
+  onFileRemove,
+  error,
+  dragActive,
+  handleDrag,
+  handleDrop,
+  skipRows,
+  onSkipRowsChange,
+  rowSize,
+  onRowSizeChange,
+  previewData,
+  previewStatementMutation,
+  onStepChange,
+}: FallbackParsingProps) {
+  return (
+    <div className="space-y-4 py-4">
+      <div className="space-y-2">
+        <Label>Account</Label>
+        <DropdownMenu>
+          <DropdownMenuTrigger asChild>
+            <Button
+              variant="outline"
+              className="w-full justify-start text-left font-normal flex items-center"
+              type="button"
+            >
+              {(() => {
+                const selected = accounts.find(
+                  (acc) => acc.id === selectedAccountId
+                );
+                return selected
+                  ? `${selected.name} (${selected.bank_type.toUpperCase()})`
+                  : "Select account";
+              })()}
+              <ChevronDownIcon className="ml-auto w-4 h-4 opacity-60" />
+            </Button>
+          </DropdownMenuTrigger>
+          <DropdownMenuContent className="w-56 max-h-64 overflow-y-auto">
+            {accounts.map((account) => (
+              <DropdownMenuItem
+                key={account.id}
+                onClick={() => onSelectedAccountIdChange(account.id)}
+                className={`py-1 px-2 text-sm min-h-0 h-8 cursor-pointer flex items-center ${
+                  selectedAccountId === account.id
+                    ? "bg-accent/40 font-semibold"
+                    : ""
+                }`}
+              >
+                {account.name} ({account.bank_type.toUpperCase()})
+              </DropdownMenuItem>
+            ))}
+          </DropdownMenuContent>
+        </DropdownMenu>
+      </div>
+
+      <div className="grid grid-cols-2 gap-4">
+        <div className="space-y-2">
+          <div className="flex items-center space-x-2">
+            <Label htmlFor="skip-rows">Skip Rows</Label>
+            <TooltipProvider>
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <AlertCircle className="h-4 w-4 text-muted-foreground" />
+                </TooltipTrigger>
+                <TooltipContent>
+                  <p>Number of rows to skip from the top of the file.</p>
+                </TooltipContent>
+              </Tooltip>
+            </TooltipProvider>
+          </div>
+          <Input
+            id="skip-rows"
+            type="number"
+            value={skipRows}
+            onChange={onSkipRowsChange}
+            min="0"
+          />
+        </div>
+        <div className="space-y-2">
+          <div className="flex items-center space-x-2">
+            <Label htmlFor="row-size">Row Size</Label>
+            <TooltipProvider>
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <AlertCircle className="h-4 w-4 text-muted-foreground" />
+                </TooltipTrigger>
+                <TooltipContent>
+                  <p>Number of rows to display in the preview.</p>
+                </TooltipContent>
+              </Tooltip>
+            </TooltipProvider>
+          </div>
+          <Input
+            id="row-size"
+            type="number"
+            value={rowSize}
+            onChange={onRowSizeChange}
+            min="1"
+          />
+        </div>
+      </div>
+
+      <div className="space-y-2">
+        <Label>Statement File</Label>
+        {!selectedFile ? (
+          <div
+            onDragEnter={handleDrag}
+            onDragLeave={handleDrag}
+            onDragOver={handleDrag}
+            onDrop={handleDrop}
+            className={`border-2 border-dashed rounded-lg p-6 text-center cursor-pointer transition-colors ${
+              dragActive
+                ? "border-primary bg-primary/5"
+                : "border-border hover:border-primary dark:border-border dark:hover:border-primary"
+            }`}
+            onClick={() =>
+              document.getElementById("file-input-fallback")?.click()
+            }
+          >
+            <Upload className="mx-auto h-12 w-12 text-muted-foreground mb-4" />
+            <p className="text-sm text-foreground mb-2">
+              {dragActive
+                ? "Drop the file here..."
+                : "Drag & drop your bank statement here, or click to select"}
+            </p>
+            <p className="text-xs text-muted-foreground">
+              Supports CSV, XLS files (max 256KB)
+            </p>
+            <Input
+              id="file-input-fallback"
+              type="file"
+              accept=".csv,.xls"
+              onChange={onFileInputChange}
+              className="hidden"
+            />
+          </div>
+        ) : (
+          <div className="border rounded-lg p-4 bg-muted/50 dark:bg-muted/20">
+            <div className="flex items-center justify-between">
+              <div className="flex items-center space-x-3">
+                <FileText className="h-8 w-8 text-blue-500 dark:text-blue-400" />
+                <div>
+                  <p className="text-sm font-medium text-foreground">
+                    {selectedFile.name}
+                  </p>
+                  <p className="text-xs text-muted-foreground">
+                    {(selectedFile.size / 1024).toFixed(1)} KB
+                  </p>
+                </div>
+              </div>
+              <Button
+                type="button"
+                variant="outline"
+                size="sm"
+                onClick={onFileRemove}
+              >
+                <X className="h-4 w-4" />
+              </Button>
+            </div>
+          </div>
+        )}
+      </div>
+
+      {(previewData || previewStatementMutation.isPending) && (
+        <div className="w-110">
+          <div className="relative max-h-64 overflow-auto border rounded-md">
+            <Table>
+              <TableHeader className="sticky top-0 bg-background">
+                <TableRow className="bg-muted/50">
+                  {previewData?.headers.map((header, i) => (
+                    <TableHead key={i}>{header}</TableHead>
+                  ))}
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {previewStatementMutation.isPending ? (
+                  <TableRow>
+                    <TableCell
+                      colSpan={previewData?.headers.length || 5}
+                      className="text-center"
+                    >
+                      Loading preview...
+                    </TableCell>
+                  </TableRow>
+                ) : (
+                  previewData?.rows.map((row, i) => (
+                    <TableRow key={i}>
+                      {row.map((cell, j) => (
+                        <TableCell key={j}>{cell}</TableCell>
+                      ))}
+                    </TableRow>
+                  ))
+                )}
+              </TableBody>
+            </Table>
+          </div>
+        </div>
+      )}
+
+      {error && (
+        <div className="text-sm text-destructive flex items-center space-x-2">
+          <AlertCircle className="h-4 w-4" />
+          <span>{error}</span>
+        </div>
+      )}
+
+      <DialogFooter>
+        <Button type="button" variant="outline" onClick={() => onStepChange(1)}>
+          Back
+        </Button>
+        <Button
+          type="button"
+          disabled={!previewData || !selectedAccountId}
+          onClick={() => onStepChange(4)}
+        >
+          Next
+        </Button>
+      </DialogFooter>
+    </div>
+  );
+}

--- a/frontend/components/custom/Modal/Statement/steps/ImportFromBank.tsx
+++ b/frontend/components/custom/Modal/Statement/steps/ImportFromBank.tsx
@@ -1,3 +1,6 @@
+import { LoadingButton } from "@/components/ui/LoadingButton";
+import { Button } from "@/components/ui/button";
+import { DialogFooter } from "@/components/ui/dialog";
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -6,6 +9,10 @@ import {
 } from "@/components/ui/dropdown-menu";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
+import { Account } from "@/lib/models/account";
+import { StatementUploadResponse } from "@/lib/models/statement";
+import { CreateStatementRequest } from "@/lib/models/statement";
+import { UseMutationResult } from "@tanstack/react-query";
 import {
   AlertCircle,
   ChevronDownIcon,
@@ -13,13 +20,6 @@ import {
   Upload,
   X,
 } from "lucide-react";
-import { Account } from "@/lib/models/account";
-import { Button } from "@/components/ui/button";
-import { DialogFooter } from "@/components/ui/dialog";
-import { UseMutationResult } from "@tanstack/react-query";
-import { StatementUploadResponse } from "@/lib/models/statement";
-import { CreateStatementRequest } from "@/lib/models/statement";
-import { LoadingButton } from "@/components/ui/LoadingButton";
 
 interface ImportFromBankProps {
   accounts: Account[];
@@ -177,7 +177,8 @@ export function ImportFromBank({
               <ul className="text-xs space-y-1 text-blue-600 dark:text-blue-400">
                 <li>• Your statement will be processed in the background</li>
                 <li>
-                  • You can check the processing status in the statements history
+                  • You can check the processing status in the statements
+                  history
                 </li>
               </ul>
             </div>

--- a/frontend/components/custom/Modal/Statement/steps/ImportFromBank.tsx
+++ b/frontend/components/custom/Modal/Statement/steps/ImportFromBank.tsx
@@ -1,0 +1,203 @@
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import {
+  AlertCircle,
+  ChevronDownIcon,
+  FileText,
+  Upload,
+  X,
+} from "lucide-react";
+import { Account } from "@/lib/models/account";
+import { Button } from "@/components/ui/button";
+import { DialogFooter } from "@/components/ui/dialog";
+import { UseMutationResult } from "@tanstack/react-query";
+import { StatementUploadResponse } from "@/lib/models/statement";
+import { CreateStatementRequest } from "@/lib/models/statement";
+import { LoadingButton } from "@/components/ui/LoadingButton";
+
+interface ImportFromBankProps {
+  accounts: Account[];
+  selectedAccountId: number;
+  onSelectedAccountIdChange: (id: number) => void;
+  selectedFile: File | null;
+  onFileInputChange: (e: React.ChangeEvent<HTMLInputElement>) => void;
+  onFileRemove: () => void;
+  error: string;
+  dragActive: boolean;
+  handleDrag: (e: React.DragEvent) => void;
+  handleDrop: (e: React.DragEvent) => void;
+  handleSubmit: (e: React.FormEvent) => void;
+  onStepChange: (step: number) => void;
+  uploadStatementMutation: UseMutationResult<
+    StatementUploadResponse,
+    Error,
+    CreateStatementRequest,
+    unknown
+  >;
+}
+
+export function ImportFromBank({
+  accounts,
+  selectedAccountId,
+  onSelectedAccountIdChange,
+  selectedFile,
+  onFileInputChange,
+  onFileRemove,
+  error,
+  dragActive,
+  handleDrag,
+  handleDrop,
+  handleSubmit,
+  onStepChange,
+  uploadStatementMutation,
+}: ImportFromBankProps) {
+  return (
+    <form onSubmit={handleSubmit}>
+      <div className="space-y-6 py-4">
+        {/* Account Selection */}
+        <div className="space-y-2">
+          <Label>Account</Label>
+          <DropdownMenu>
+            <DropdownMenuTrigger asChild>
+              <Button
+                variant="outline"
+                className="w-full justify-start text-left font-normal flex items-center"
+                type="button"
+              >
+                {(() => {
+                  const selected = accounts.find(
+                    (acc) => acc.id === selectedAccountId
+                  );
+                  return selected
+                    ? `${selected.name} (${selected.bank_type.toUpperCase()})`
+                    : "Select account";
+                })()}
+                <ChevronDownIcon className="ml-auto w-4 h-4 opacity-60" />
+              </Button>
+            </DropdownMenuTrigger>
+            <DropdownMenuContent className="w-56 max-h-64 overflow-y-auto">
+              {accounts.map((account) => (
+                <DropdownMenuItem
+                  key={account.id}
+                  onClick={() => onSelectedAccountIdChange(account.id)}
+                  className={`py-1 px-2 text-sm min-h-0 h-8 cursor-pointer flex items-center ${
+                    selectedAccountId === account.id
+                      ? "bg-accent/40 font-semibold"
+                      : ""
+                  }`}
+                >
+                  {account.name} ({account.bank_type.toUpperCase()})
+                </DropdownMenuItem>
+              ))}
+            </DropdownMenuContent>
+          </DropdownMenu>
+        </div>
+
+        {/* File Upload */}
+        <div className="space-y-2">
+          <Label>Statement File</Label>
+          <div className="space-y-4">
+            {!selectedFile ? (
+              <div
+                onDragEnter={handleDrag}
+                onDragLeave={handleDrag}
+                onDragOver={handleDrag}
+                onDrop={handleDrop}
+                className={`border-2 border-dashed rounded-lg p-6 text-center cursor-pointer transition-colors ${
+                  dragActive
+                    ? "border-primary bg-primary/5"
+                    : "border-border hover:border-primary dark:border-border dark:hover:border-primary"
+                }`}
+                onClick={() => document.getElementById("file-input")?.click()}
+              >
+                <Upload className="mx-auto h-12 w-12 text-muted-foreground mb-4" />
+                <p className="text-sm text-foreground mb-2">
+                  {dragActive
+                    ? "Drop the file here..."
+                    : "Drag & drop your bank statement here, or click to select"}
+                </p>
+                <p className="text-xs text-muted-foreground">
+                  Supports CSV, XLS, XLSX files (max 256KB)
+                </p>
+                <Input
+                  id="file-input"
+                  type="file"
+                  accept=".csv,.xls,.xlsx"
+                  onChange={onFileInputChange}
+                  className="hidden"
+                />
+              </div>
+            ) : (
+              <div className="border rounded-lg p-4 bg-muted/50 dark:bg-muted/20">
+                <div className="flex items-center justify-between">
+                  <div className="flex items-center space-x-3">
+                    <FileText className="h-8 w-8 text-blue-500 dark:text-blue-400" />
+                    <div>
+                      <p className="text-sm font-medium text-foreground">
+                        {selectedFile.name}
+                      </p>
+                      <p className="text-xs text-muted-foreground">
+                        {(selectedFile.size / 1024).toFixed(1)} KB
+                      </p>
+                    </div>
+                  </div>
+                  <Button
+                    type="button"
+                    variant="outline"
+                    size="sm"
+                    onClick={onFileRemove}
+                  >
+                    <X className="h-4 w-4" />
+                  </Button>
+                </div>
+              </div>
+            )}
+
+            {/* Error Display */}
+            {error && (
+              <div className="text-sm text-destructive flex items-center space-x-2">
+                <AlertCircle className="h-4 w-4" />
+                <span>{error}</span>
+              </div>
+            )}
+          </div>
+        </div>
+
+        <div className="bg-blue-50 dark:bg-blue-950/50 border border-blue-200 dark:border-blue-800 rounded-lg p-4">
+          <div className="flex items-start space-x-3">
+            <AlertCircle className="h-5 w-5 text-blue-500 dark:text-blue-400 mt-0.5" />
+            <div className="text-sm text-blue-700 dark:text-blue-300">
+              <p className="font-medium mb-1">Processing Information:</p>
+              <ul className="text-xs space-y-1 text-blue-600 dark:text-blue-400">
+                <li>• Your statement will be processed in the background</li>
+                <li>
+                  • You can check the processing status in the statements history
+                </li>
+              </ul>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <DialogFooter>
+        <Button type="button" variant="outline" onClick={() => onStepChange(1)}>
+          Back
+        </Button>
+        <LoadingButton
+          type="submit"
+          loading={uploadStatementMutation.isPending}
+          disabled={uploadStatementMutation.isPending || !selectedFile}
+          fixedWidth="140px"
+        >
+          Import Statement
+        </LoadingButton>
+      </DialogFooter>
+    </form>
+  );
+}

--- a/frontend/components/custom/Modal/Statement/steps/MapColumns.tsx
+++ b/frontend/components/custom/Modal/Statement/steps/MapColumns.tsx
@@ -1,0 +1,144 @@
+import { Button } from "@/components/ui/button";
+import { DialogFooter } from "@/components/ui/dialog";
+import { Label } from "@/components/ui/label";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { AlertCircle } from "lucide-react";
+import { useState } from "react";
+
+interface MapColumnsProps {
+  headers: string[];
+  onStepChange: (step: number) => void;
+  onCancel: () => void;
+  onSubmit: (mappings: Record<string, string>) => void;
+}
+
+const requiredFields = [
+  { value: "txn_date", label: "Transaction Date" },
+  { value: "name", label: "Name" },
+  { value: "description", label: "Description (Optional)" },
+  { value: "amount", label: "Amount" },
+  { value: "credit", label: "Credit" },
+  { value: "debit", label: "Debit" },
+];
+
+export function MapColumns({
+  headers,
+  onStepChange,
+  onCancel,
+  onSubmit,
+}: MapColumnsProps) {
+  const [mappings, setMappings] = useState<Record<string, string>>({});
+  const [error, setError] = useState<string>("");
+
+  const handleMappingChange = (field: string, header: string) => {
+    setMappings((prev) => {
+      const updated = { ...prev };
+      if (header === "" || header === "none") {
+        delete updated[field];
+      } else {
+        updated[field] = header;
+      }
+      return updated;
+    });
+  };
+
+  const validateMappings = () => {
+    if (!mappings.txn_date) {
+      return "Transaction Date must be mapped.";
+    }
+    if (!mappings.name) {
+      return "Name must be mapped.";
+    }
+    const hasAmount = !!mappings.amount;
+    const hasCreditDebit = !!mappings.credit && !!mappings.debit;
+    if (!hasAmount && !hasCreditDebit) {
+      return "You must map either 'Amount' or both 'Credit' and 'Debit'.";
+    }
+    if (hasAmount && (mappings.credit || mappings.debit)) {
+      return "You cannot map 'Amount' with 'Credit' or 'Debit'. Please choose one method.";
+    }
+    return "";
+  };
+
+  const handleNext = () => {
+    const validationError = validateMappings();
+    if (validationError) {
+      setError(validationError);
+      return;
+    }
+    setError("");
+    onSubmit(mappings);
+    onCancel();
+  };
+
+  return (
+    <div className="space-y-4 py-4">
+      <div className="bg-blue-50 dark:bg-blue-950/50 border border-blue-200 dark:border-blue-800 rounded-lg p-3">
+        <div className="flex items-start space-x-3">
+          <AlertCircle className="h-5 w-5 text-blue-500 dark:text-blue-400 mt-0.5 flex-shrink-0" />
+          <div className="text-sm text-blue-700 dark:text-blue-300">
+            <p className="font-medium">Map Your Columns</p>
+            <p className="text-xs mt-1 text-blue-600 dark:text-blue-400">
+              Match the columns from your file to the required transaction
+              fields. For amounts, you can use a single &apos;Amount&apos;
+              column or separate &apos;Credit&apos; and &apos;Debit&apos;
+              columns.
+            </p>
+          </div>
+        </div>
+      </div>
+
+      <div className="space-y-4">
+        {requiredFields.map((field) => (
+          <div key={field.value} className="flex items-center justify-between">
+            <Label>{field.label}</Label>
+            <div className="w-1/2">
+              <Select
+                value={mappings[field.value] || ""}
+                onValueChange={(value) =>
+                  handleMappingChange(field.value, value)
+                }
+              >
+                <SelectTrigger className="w-full">
+                  <SelectValue placeholder="Select a column" />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="none">None</SelectItem>
+                  {headers
+                    .filter((h) => h)
+                    .map((header, i) => (
+                      <SelectItem key={i} value={header}>
+                        {header}
+                      </SelectItem>
+                    ))}
+                </SelectContent>
+              </Select>
+            </div>
+          </div>
+        ))}
+      </div>
+
+      {error && (
+        <div className="text-sm text-destructive flex items-center space-x-2 pt-2">
+          <AlertCircle className="h-4 w-4" />
+          <span>{error}</span>
+        </div>
+      )}
+
+      <DialogFooter>
+        <Button type="button" variant="outline" onClick={() => onStepChange(3)}>
+          Back
+        </Button>
+        <Button type="button" onClick={handleNext}>
+          Process Transactions
+        </Button>
+      </DialogFooter>
+    </div>
+  );
+}

--- a/frontend/components/custom/Modal/Statement/steps/SelectBank.tsx
+++ b/frontend/components/custom/Modal/Statement/steps/SelectBank.tsx
@@ -1,0 +1,43 @@
+import { Button } from "@/components/ui/button";
+import { FileCog, Landmark } from "lucide-react";
+
+interface SelectBankProps {
+  onStepChange: (step: number) => void;
+}
+
+export function SelectBank({ onStepChange }: SelectBankProps) {
+  return (
+    <div className="py-4 space-y-4">
+      <Button
+        variant="outline"
+        className="w-full justify-start p-4 h-auto flex items-center space-x-4"
+        onClick={() => onStepChange(2)}
+      >
+        <div className="bg-blue-100 dark:bg-blue-900/50 p-3 rounded-lg">
+          <Landmark className="h-6 w-6 text-blue-600 dark:text-blue-400" />
+        </div>
+        <div className="text-left">
+          <p className="font-semibold">Import from Bank</p>
+          <p className="text-xs text-muted-foreground">
+            Recommended for supported banks.
+          </p>
+        </div>
+      </Button>
+      <Button
+        variant="outline"
+        className="w-full justify-start p-4 h-auto flex items-center space-x-4"
+        onClick={() => onStepChange(3)}
+      >
+        <div className="bg-green-100 dark:bg-green-900/50 p-3 rounded-lg">
+          <FileCog className="h-6 w-6 text-green-600 dark:text-green-400" />
+        </div>
+        <div className="text-left">
+          <p className="font-semibold">Custom Parsing</p>
+          <p className="text-xs text-muted-foreground">
+            For unsupported banks or parsing failures.
+          </p>
+        </div>
+      </Button>
+    </div>
+  );
+}

--- a/frontend/components/hooks/useStatements.ts
+++ b/frontend/components/hooks/useStatements.ts
@@ -1,10 +1,14 @@
 import {
   getStatement,
   listStatements,
+  previewStatement,
   uploadStatement,
 } from "@/lib/api/statement";
 import { PaginatedStatementResponse } from "@/lib/api/statement";
-import { CreateStatementRequest } from "@/lib/models/statement";
+import {
+  CreateStatementRequest,
+  StatementPreviewResponse,
+} from "@/lib/models/statement";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { toast } from "sonner";
 
@@ -50,6 +54,20 @@ export const useUploadStatement = () => {
     },
     onError: (error: Error) => {
       toast.error(error.message || "Failed to upload statement");
+    },
+  });
+};
+
+export const usePreviewStatement = () => {
+  return useMutation<
+    StatementPreviewResponse,
+    Error,
+    { file: File; skipRows: number; rowSize: number }
+  >({
+    mutationFn: ({ file, skipRows, rowSize }) =>
+      previewStatement(file, skipRows, rowSize),
+    onError: (error: Error) => {
+      toast.error(error.message || "Failed to preview statement");
     },
   });
 };

--- a/frontend/lib/api/statement.ts
+++ b/frontend/lib/api/statement.ts
@@ -85,7 +85,10 @@ export async function previewStatement(
 ): Promise<StatementPreviewResponse> {
   const formData = new FormData();
   formData.append("file", file);
-  formData.append("metadata", JSON.stringify({ skip_rows: skipRows, row_size: rowSize }));
+  formData.append(
+    "metadata",
+    JSON.stringify({ skip_rows: skipRows, row_size: rowSize })
+  );
 
   const response = await fetch(`${API_BASE_URL}/statement/preview`, {
     method: "POST",

--- a/frontend/lib/api/statement.ts
+++ b/frontend/lib/api/statement.ts
@@ -3,6 +3,7 @@ import { API_BASE_URL } from "@/lib/constants/api";
 import {
   CreateStatementRequest,
   Statement,
+  StatementPreviewResponse,
   StatementUploadResponse,
 } from "@/lib/models/statement";
 
@@ -12,6 +13,13 @@ export async function uploadStatement(
   const formData = new FormData();
   formData.append("account_id", data.account_id.toString());
   formData.append("file", data.file);
+
+  if (data.bank_type) {
+    formData.append("bank_type", data.bank_type);
+  }
+  if (data.metadata) {
+    formData.append("metadata", data.metadata);
+  }
 
   const response = await fetch(`${API_BASE_URL}/statement`, {
     method: "POST",
@@ -68,4 +76,28 @@ export async function getStatement(id: number): Promise<Statement> {
     [],
     "Failed to fetch statement"
   );
+}
+
+export async function previewStatement(
+  file: File,
+  skipRows: number,
+  rowSize: number
+): Promise<StatementPreviewResponse> {
+  const formData = new FormData();
+  formData.append("file", file);
+  formData.append("metadata", JSON.stringify({ skip_rows: skipRows, row_size: rowSize }));
+
+  const response = await fetch(`${API_BASE_URL}/statement/preview`, {
+    method: "POST",
+    credentials: "include",
+    body: formData,
+  });
+
+  if (!response.ok) {
+    const errorData = await response.json().catch(() => ({}));
+    throw new Error(errorData.error || "Failed to preview statement");
+  }
+
+  const result = await response.json();
+  return result.data;
 }

--- a/frontend/lib/models/statement.ts
+++ b/frontend/lib/models/statement.ts
@@ -14,9 +14,16 @@ export interface Statement {
 export interface CreateStatementRequest {
   account_id: number;
   file: File;
+  bank_type?: string;
+  metadata?: string;
 }
 
 export interface StatementUploadResponse {
   statement: Statement;
   message: string;
+}
+
+export interface StatementPreviewResponse {
+  headers: string[];
+  rows: string[][];
 }

--- a/justfile
+++ b/justfile
@@ -81,3 +81,8 @@ db-downgrade-reset reset=default_downgrade:
 
 @test test_file="":
   cd server && bash e2e_test.sh {{test_file}}
+  
+# Start the frontend development server
+[working-directory: 'frontend']
+@frontend:
+    npm run dev

--- a/server/internal/api/controller/statement_controller_test.go
+++ b/server/internal/api/controller/statement_controller_test.go
@@ -298,6 +298,326 @@ var _ = Describe("StatementController", func() {
 		})
 	})
 
+	Describe("PreviewStatement", func() {
+		It("should successfully preview a valid CSV statement file", func() {
+			fileContent := []byte(
+				"Txn Date\tValue Date\tDescription\tRef No.\tDebit\tCredit\tBalance\n" +
+					"1 Aug 2022\t1 Aug 2022\tTO TRANSFER-UPI\t123456\t100.00\t\t1000.00\n" +
+					"2 Aug 2022\t2 Aug 2022\tBY TRANSFER-NEFT\t654321\t\t200.00\t1200.00\n" +
+					"3 Aug 2022\t3 Aug 2022\tATM WITHDRAWAL\t789012\t50.00\t\t1150.00\n" +
+					"Computer Generated Statement")
+
+			previewInput := map[string]any{
+				"file":      fileContent,
+				"skip_rows": 0,
+				"row_size":  10,
+			}
+			resp, response := testHelperUser1.MakeMultipartRequest(http.MethodPost, "/statement/preview", previewInput)
+			Expect(resp.StatusCode).To(Equal(http.StatusOK))
+			Expect(response["message"]).To(Equal("Statement preview generated successfully"))
+			Expect(response).To(HaveKey("data"))
+
+			data := response["data"].(map[string]any)
+			Expect(data).To(HaveKey("rows"))
+			Expect(data).To(HaveKey("headers"))
+
+			rows := data["rows"].([]any)
+			Expect(len(rows)).To(BeNumerically(">", 0))
+		})
+
+		It("should successfully preview with custom skip_rows parameter", func() {
+			fileContent := []byte(
+				"Header Line 1\n" +
+					"Header Line 2\n" +
+					"Txn Date\tValue Date\tDescription\tRef No.\tDebit\tCredit\tBalance\n" +
+					"1 Aug 2022\t1 Aug 2022\tTO TRANSFER-UPI\t123456\t100.00\t\t1000.00\n" +
+					"2 Aug 2022\t2 Aug 2022\tBY TRANSFER-NEFT\t654321\t\t200.00\t1200.00\n")
+
+			previewInput := map[string]any{
+				"file":      fileContent,
+				"skip_rows": 2,
+				"row_size":  10,
+			}
+			resp, response := testHelperUser1.MakeMultipartRequest(http.MethodPost, "/statement/preview", previewInput)
+			Expect(resp.StatusCode).To(Equal(http.StatusOK))
+			Expect(response["message"]).To(Equal("Statement preview generated successfully"))
+			Expect(response).To(HaveKey("data"))
+		})
+
+		It("should successfully preview with custom row_size parameter", func() {
+			fileContent := []byte(
+				"Txn Date\tValue Date\tDescription\tRef No.\tDebit\tCredit\tBalance\n" +
+					"1 Aug 2022\t1 Aug 2022\tTO TRANSFER-UPI\t123456\t100.00\t\t1000.00\n" +
+					"2 Aug 2022\t2 Aug 2022\tBY TRANSFER-NEFT\t654321\t\t200.00\t1200.00\n" +
+					"3 Aug 2022\t3 Aug 2022\tATM WITHDRAWAL\t789012\t50.00\t\t1150.00\n" +
+					"4 Aug 2022\t4 Aug 2022\tONLINE PURCHASE\t345678\t75.00\t\t1075.00\n")
+
+			previewInput := map[string]any{
+				"file":     fileContent,
+				"row_size": 2,
+			}
+			resp, response := testHelperUser1.MakeMultipartRequest(http.MethodPost, "/statement/preview", previewInput)
+			Expect(resp.StatusCode).To(Equal(http.StatusOK))
+			Expect(response["message"]).To(Equal("Statement preview generated successfully"))
+			Expect(response).To(HaveKey("data"))
+
+			data := response["data"].(map[string]any)
+			rows := data["rows"].([]any)
+			Expect(len(rows)).To(BeNumerically("<=", 2))
+		})
+
+		It("should successfully preview with both skip_rows and row_size parameters", func() {
+			fileContent := []byte(
+				"Header Line\n" +
+					"Txn Date\tValue Date\tDescription\tRef No.\tDebit\tCredit\tBalance\n" +
+					"1 Aug 2022\t1 Aug 2022\tTO TRANSFER-UPI\t123456\t100.00\t\t1000.00\n" +
+					"2 Aug 2022\t2 Aug 2022\tBY TRANSFER-NEFT\t654321\t\t200.00\t1200.00\n" +
+					"3 Aug 2022\t3 Aug 2022\tATM WITHDRAWAL\t789012\t50.00\t\t1150.00\n")
+
+			previewInput := map[string]any{
+				"file":      fileContent,
+				"skip_rows": 1,
+				"row_size":  2,
+			}
+			resp, response := testHelperUser1.MakeMultipartRequest(http.MethodPost, "/statement/preview", previewInput)
+			Expect(resp.StatusCode).To(Equal(http.StatusOK))
+			Expect(response["message"]).To(Equal("Statement preview generated successfully"))
+			Expect(response).To(HaveKey("data"))
+		})
+
+		It("should return bad request when file is missing", func() {
+			previewInput := map[string]any{
+				"skip_rows": 0,
+				"row_size":  10,
+			}
+			resp, response := testHelperUser1.MakeMultipartRequest(http.MethodPost, "/statement/preview", previewInput)
+			Expect(resp.StatusCode).To(Equal(http.StatusBadRequest))
+			Expect(response).To(HaveKey("message"))
+		})
+
+		It("should return error for empty file", func() {
+			fileContent := []byte("")
+
+			previewInput := map[string]any{
+				"file":      fileContent,
+				"skip_rows": 0,
+				"row_size":  10,
+			}
+			resp, response := testHelperUser1.MakeMultipartRequest(http.MethodPost, "/statement/preview", previewInput)
+			Expect(resp.StatusCode).To(SatisfyAny(Equal(http.StatusBadRequest), Equal(http.StatusInternalServerError)))
+			Expect(response).To(HaveKey("message"))
+		})
+
+		It("should return error for file larger than 256kb", func() {
+			// Create a file >256kb
+			bigFile := make([]byte, 257*1024)
+			for i := range bigFile {
+				bigFile[i] = 'A'
+			}
+
+			previewInput := map[string]any{
+				"file":      bigFile,
+				"skip_rows": 0,
+				"row_size":  10,
+			}
+			resp, response := testHelperUser1.MakeMultipartRequest(http.MethodPost, "/statement/preview", previewInput)
+			Expect(resp.StatusCode).To(Equal(http.StatusBadRequest))
+			Expect(response).To(HaveKey("message"))
+		})
+
+		It("should error out invalid skip_rows parameter gracefully", func() {
+			fileContent := []byte(
+				"Txn Date\tValue Date\tDescription\tRef No.\tDebit\tCredit\tBalance\n" +
+					"1 Aug 2022\t1 Aug 2022\tTO TRANSFER-UPI\t123456\t100.00\t\t1000.00\n")
+
+			previewInput := map[string]any{
+				"file":      fileContent,
+				"skip_rows": "invalid",
+			}
+			resp, _ := testHelperUser1.MakeMultipartRequest(http.MethodPost, "/statement/preview", previewInput)
+			Expect(resp.StatusCode).To(Equal(http.StatusBadRequest))
+		})
+
+		It("should error out invalid row_size parameter gracefully", func() {
+			fileContent := []byte(
+				"Txn Date\tValue Date\tDescription\tRef No.\tDebit\tCredit\tBalance\n" +
+					"1 Aug 2022\t1 Aug 2022\tTO TRANSFER-UPI\t123456\t100.00\t\t1000.00\n")
+
+			previewInput := map[string]any{
+				"file":     fileContent,
+				"row_size": "invalid",
+			}
+			resp, _ := testHelperUser1.MakeMultipartRequest(http.MethodPost, "/statement/preview", previewInput)
+			Expect(resp.StatusCode).To(Equal(http.StatusBadRequest))
+		})
+
+		It("should error out negative skip_rows parameter", func() {
+			fileContent := []byte(
+				"Txn Date\tValue Date\tDescription\tRef No.\tDebit\tCredit\tBalance\n" +
+					"1 Aug 2022\t1 Aug 2022\tTO TRANSFER-UPI\t123456\t100.00\t\t1000.00\n")
+
+			previewInput := map[string]any{
+				"file":      fileContent,
+				"skip_rows": -1,
+			}
+			resp, _ := testHelperUser1.MakeMultipartRequest(http.MethodPost, "/statement/preview", previewInput)
+			Expect(resp.StatusCode).To(Equal(http.StatusBadRequest))
+		})
+
+		It("should error out negative row_size parameter", func() {
+			fileContent := []byte(
+				"Txn Date\tValue Date\tDescription\tRef No.\tDebit\tCredit\tBalance\n" +
+					"1 Aug 2022\t1 Aug 2022\tTO TRANSFER-UPI\t123456\t100.00\t\t1000.00\n")
+
+			previewInput := map[string]any{
+				"file":     fileContent,
+				"row_size": -1,
+			}
+			resp, _ := testHelperUser1.MakeMultipartRequest(http.MethodPost, "/statement/preview", previewInput)
+			Expect(resp.StatusCode).To(Equal(http.StatusBadRequest))
+		})
+
+		It("should handle zero row_size parameter", func() {
+			fileContent := []byte(
+				"Txn Date\tValue Date\tDescription\tRef No.\tDebit\tCredit\tBalance\n" +
+					"1 Aug 2022\t1 Aug 2022\tTO TRANSFER-UPI\t123456\t100.00\t\t1000.00\n")
+
+			previewInput := map[string]any{
+				"file":     fileContent,
+				"row_size": 0,
+			}
+			resp, response := testHelperUser1.MakeMultipartRequest(http.MethodPost, "/statement/preview", previewInput)
+			Expect(resp.StatusCode).To(Equal(http.StatusOK))
+			Expect(response["message"]).To(Equal("Statement preview generated successfully"))
+		})
+
+		It("should return unauthorized for unauthenticated user", func() {
+			fileContent := []byte(
+				"Txn Date\tValue Date\tDescription\tRef No.\tDebit\tCredit\tBalance\n" +
+					"1 Aug 2022\t1 Aug 2022\tTO TRANSFER-UPI\t123456\t100.00\t\t1000.00\n")
+
+			previewInput := map[string]any{
+				"file": fileContent,
+			}
+			resp, response := testHelperUnauthenticated.MakeMultipartRequest(http.MethodPost, "/statement/preview", previewInput)
+			Expect(resp.StatusCode).To(Equal(http.StatusUnauthorized))
+			Expect(response).To(HaveKey("message"))
+			Expect(response["message"]).To(Equal("please log in to continue"))
+		})
+
+		It("should return appropriate preview structure", func() {
+			fileContent := []byte(
+				"Txn Date\tValue Date\tDescription\tRef No.\tDebit\tCredit\tBalance\n" +
+					"1 Aug 2022\t1 Aug 2022\tTO TRANSFER-UPI\t123456\t100.00\t\t1000.00\n" +
+					"2 Aug 2022\t2 Aug 2022\tBY TRANSFER-NEFT\t654321\t\t200.00\t1200.00\n")
+
+			previewInput := map[string]any{
+				"file": fileContent,
+			}
+			resp, response := testHelperUser1.MakeMultipartRequest(http.MethodPost, "/statement/preview", previewInput)
+			Expect(resp.StatusCode).To(Equal(http.StatusOK))
+			Expect(response["message"]).To(Equal("Statement preview generated successfully"))
+			Expect(response).To(HaveKey("data"))
+
+			data := response["data"].(map[string]any)
+			Expect(data).To(HaveKey("rows"))
+			Expect(data).To(HaveKey("headers"))
+
+			headers := data["headers"].([]any)
+			Expect(len(headers)).To(BeNumerically(">", 0))
+
+			rows := data["rows"].([]any)
+			Expect(len(rows)).To(BeNumerically(">", 0))
+		})
+
+		It("should handle CSV with comma delimiters", func() {
+			fileContent := []byte(
+				"Txn Date,Value Date,Description,Ref No.,Debit,Credit,Balance\n" +
+					"1 Aug 2022,1 Aug 2022,TO TRANSFER-UPI,123456,100.00,,1000.00\n" +
+					"2 Aug 2022,2 Aug 2022,BY TRANSFER-NEFT,654321,,200.00,1200.00\n")
+
+			previewInput := map[string]any{
+				"file": fileContent,
+			}
+			resp, response := testHelperUser1.MakeMultipartRequest(http.MethodPost, "/statement/preview", previewInput)
+			Expect(resp.StatusCode).To(Equal(http.StatusOK))
+			Expect(response["message"]).To(Equal("Statement preview generated successfully"))
+			Expect(response).To(HaveKey("data"))
+		})
+
+		It("should handle files with special characters", func() {
+			fileContent := []byte(
+				"Txn Date\tValue Date\tDescription\tRef No.\tDebit\tCredit\tBalance\n" +
+					"1 Aug 2022\t1 Aug 2022\tTÖ TRÄNSFÉR-UPI\t123456\t₹100.00\t\t₹1000.00\n" +
+					"2 Aug 2022\t2 Aug 2022\tBY TRÄNSFÉR-NEFT\t654321\t\t₹200.00\t₹1200.00\n")
+
+			previewInput := map[string]any{
+				"file": fileContent,
+			}
+			resp, response := testHelperUser1.MakeMultipartRequest(http.MethodPost, "/statement/preview", previewInput)
+			Expect(resp.StatusCode).To(Equal(http.StatusOK))
+			Expect(response["message"]).To(Equal("Statement preview generated successfully"))
+			Expect(response).To(HaveKey("data"))
+		})
+
+		It("should handle malformed CSV gracefully", func() {
+			fileContent := []byte(
+				"Txn Date\tValue Date\tDescription\tRef No.\tDebit\tCredit\tBalance\n" +
+					"1 Aug 2022\t1 Aug 2022\tTO TRANSFER-UPI\t123456\t100.00\n" + // Missing columns
+					"INVALID ROW WITH NO TABS\n" +
+					"2 Aug 2022\t2 Aug 2022\tBY TRANSFER-NEFT\t654321\t\t200.00\t1200.00\n")
+
+			previewInput := map[string]any{
+				"file": fileContent,
+			}
+			resp, response := testHelperUser1.MakeMultipartRequest(http.MethodPost, "/statement/preview", previewInput)
+			// Should either succeed with partial data or return an appropriate error
+			Expect(resp.StatusCode).To(SatisfyAny(Equal(http.StatusOK), Equal(http.StatusBadRequest), Equal(http.StatusInternalServerError)))
+			Expect(response).To(HaveKey("message"))
+		})
+
+		It("should handle very large row_size parameter", func() {
+			fileContent := []byte(
+				"Txn Date\tValue Date\tDescription\tRef No.\tDebit\tCredit\tBalance\n" +
+					"1 Aug 2022\t1 Aug 2022\tTO TRANSFER-UPI\t123456\t100.00\t\t1000.00\n" +
+					"2 Aug 2022\t2 Aug 2022\tBY TRANSFER-NEFT\t654321\t\t200.00\t1200.00\n")
+
+			previewInput := map[string]any{
+				"file":     fileContent,
+				"row_size": 10000,
+			}
+			resp, response := testHelperUser1.MakeMultipartRequest(http.MethodPost, "/statement/preview", previewInput)
+			Expect(resp.StatusCode).To(Equal(http.StatusOK))
+			Expect(response["message"]).To(Equal("Statement preview generated successfully"))
+			Expect(response).To(HaveKey("data"))
+
+			data := response["data"].(map[string]any)
+			rows := data["rows"].([]any)
+			// Should return all available rows, not more than what exists
+			Expect(len(rows)).To(BeNumerically("<=", 10000))
+		})
+
+		It("should handle very large skip_rows parameter", func() {
+			fileContent := []byte(
+				"Txn Date\tValue Date\tDescription\tRef No.\tDebit\tCredit\tBalance\n" +
+					"1 Aug 2022\t1 Aug 2022\tTO TRANSFER-UPI\t123456\t100.00\t\t1000.00\n")
+
+			previewInput := map[string]any{
+				"file":      fileContent,
+				"skip_rows": 10000,
+			}
+			resp, response := testHelperUser1.MakeMultipartRequest(http.MethodPost, "/statement/preview", previewInput)
+			Expect(resp.StatusCode).To(Equal(http.StatusOK))
+			Expect(response["message"]).To(Equal("Statement preview generated successfully"))
+			Expect(response).To(HaveKey("data"))
+
+			data := response["data"].(map[string]any)
+			rows := data["rows"].([]any)
+			// Should return empty or minimal rows since we're skipping more than available
+			Expect(len(rows)).To(BeNumerically(">=", 0))
+		})
+	})
+
 	Describe("CreateStatement", func() {
 		It("should create a statement, wait for status to be success, and verify transaction inclusion", func() {
 			// 1. Signup a new user

--- a/server/internal/api/routes.go
+++ b/server/internal/api/routes.go
@@ -108,6 +108,7 @@ func Init(
 		statement := base.Group("/statement", middleware.Protected(cfg))
 		{
 			statement.POST("", statementController.CreateStatement)
+			statement.POST("/preview", statementController.PreviewStatement)
 			statement.GET("", statementController.GetStatements)
 			statement.GET("/:id", statementController.GetStatementStatus)
 		}

--- a/server/internal/errors/statement.go
+++ b/server/internal/errors/statement.go
@@ -17,3 +17,7 @@ func NewStatementGetError(err error) *AuthError {
 func NewStatementUpdateError(err error) *AuthError {
 	return formatError(http.StatusInternalServerError, "failed to update statement", err, "StatementUpdateError")
 }
+
+func NewStatementBadRequestError(err error) *AuthError {
+	return formatError(http.StatusBadRequest, "invalid request", err, "StatementBadRequestError")
+}

--- a/server/internal/models/statement.go
+++ b/server/internal/models/statement.go
@@ -1,6 +1,9 @@
 package models
 
-import "time"
+import (
+	"mime/multipart"
+	"time"
+)
 
 type StatementStatus string
 
@@ -18,6 +21,15 @@ type CreateStatementInput struct {
 	FileType         string          `json:"file_type" binding:"required"`
 	Status           StatementStatus `json:"status" binding:"required,oneof=pending processing done error"`
 	Message          *string         `json:"message,omitempty"`
+}
+
+type ParseStatementInput struct {
+	FileBytes        []byte `json:"file_bytes" binding:"required"`
+	FileName         string `json:"file_name" binding:"required"`
+	AccountId        int64  `json:"account_id" binding:"required"`
+	OriginalFilename string `json:"original_filename" binding:"required"`
+	BankType         string `json:"bank_type,omitempty" binding:"optional"`
+	Metadata         string `json:"metadata,omitempty" binding:"optional"`
 }
 
 type UpdateStatementStatusInput struct {
@@ -41,4 +53,23 @@ type PaginatedStatementResponse struct {
 	Total      int                 `json:"total"`
 	Page       int                 `json:"page"`
 	PageSize   int                 `json:"page_size"`
+}
+
+type StatementPreview struct {
+	Headers []string   `json:"headers"`
+	Rows    [][]string `json:"rows"`
+}
+
+// Form parsing
+type ParseStatementForm struct {
+	AccountId int64                 `form:"account_id" binding:"required"`
+	BankType  string                `form:"bank_type"`
+	Metadata  string                `form:"metadata"`
+	File      *multipart.FileHeader `form:"file" binding:"required"`
+}
+
+type PreviewStatementForm struct {
+	SkipRows int                   `form:"skip_rows"`
+	RowSize  int                   `form:"row_size"`
+	File     *multipart.FileHeader `form:"file" binding:"required"`
 }

--- a/server/internal/parser/custom_parser.go
+++ b/server/internal/parser/custom_parser.go
@@ -1,0 +1,259 @@
+package parser
+
+import (
+	"bytes"
+	"encoding/csv"
+	"encoding/json"
+	"errors"
+	"expenses/internal/models"
+	"expenses/pkg/logger"
+	"expenses/pkg/utils"
+	"fmt"
+	"path/filepath"
+	"strings"
+)
+
+type CustomParser struct{}
+
+// StatementMetadata defines the structure for custom parser configuration.
+type StatementMetadata struct {
+	SkipRows      int               `json:"skip_rows"`
+	ColumnMapping map[string]string `json:"column_mapping"`
+}
+
+// trimRecords iterates through a 2D string slice and trims whitespace from each element.
+func trimRecords(records [][]string) [][]string {
+	trimmed := make([][]string, len(records))
+	for i, row := range records {
+		trimmedRow := make([]string, len(row))
+		for j, field := range row {
+			trimmedRow[j] = strings.TrimSpace(field)
+		}
+		trimmed[i] = trimmedRow
+	}
+	return trimmed
+}
+
+func (p *CustomParser) Preview(fileBytes []byte, fileName string, skipRows int, rowSize int) (*models.StatementPreview, error) {
+	logger.Infof("Parser: Processing file '%s'", fileName)
+	lowerFileName := strings.ToLower(fileName)
+	extension := filepath.Ext(lowerFileName)
+
+	var records [][]string
+	var err error
+
+	switch extension {
+	case ".csv":
+		r := csv.NewReader(bytes.NewReader(fileBytes))
+		r.FieldsPerRecord = -1 // To handle "wrong number of fields" error
+		records, err = r.ReadAll()
+		if err != nil {
+			return nil, fmt.Errorf("failed to read csv: %w", err)
+		}
+	case ".xls":
+		r := csv.NewReader(bytes.NewReader(fileBytes))
+		r.Comma = '\t'
+		r.FieldsPerRecord = -1 // To handle "wrong number of fields" error
+		records, err = r.ReadAll()
+		if err != nil {
+			return nil, fmt.Errorf("failed to read tsv from xls file: %w", err)
+		}
+	default:
+		return nil, fmt.Errorf("unsupported file type for preview: %s. Only .csv and .xls are supported", fileName)
+	}
+
+	// Trim whitespace from all records at once to ensure clean data.
+	records = trimRecords(records)
+
+	if len(records) <= skipRows {
+		return &models.StatementPreview{Headers: []string{}, Rows: [][]string{}}, nil
+	}
+
+	// Skip rows to drop the metadata or header rows
+	records = records[skipRows:]
+
+	if len(records) == 0 {
+		return &models.StatementPreview{Headers: []string{}, Rows: [][]string{}}, nil
+	}
+
+	headers := records[0]
+	dataRows := records[1:]
+
+	if rowSize != -1 && len(dataRows) > rowSize {
+		dataRows = dataRows[:rowSize]
+	}
+
+	preview := &models.StatementPreview{
+		Headers: headers,
+		Rows:    dataRows,
+	}
+
+	return preview, nil
+}
+
+// Parse processes a file using metadata to map columns and create transactions.
+func (p *CustomParser) Parse(fileBytes []byte, metadata string, fileName string) ([]models.CreateTransactionInput, error) {
+	if metadata == "" {
+		return nil, errors.New("metadata is required for custom parser")
+	}
+
+	var meta StatementMetadata
+	if err := json.Unmarshal([]byte(metadata), &meta); err != nil {
+		return nil, fmt.Errorf("failed to unmarshal metadata: %w", err)
+	}
+
+	preview, err := p.Preview(fileBytes, fileName, meta.SkipRows, -1)
+	if err != nil {
+		return nil, fmt.Errorf("failed to preview file for parsing: %w", err)
+	}
+
+	// Create a map of header names to their column index. Data is already trimmed by Preview.
+	headerIndex := make(map[string]int, len(preview.Headers))
+	for i, h := range preview.Headers {
+		headerIndex[h] = i
+	}
+
+	columnIndex := make(map[string]int)
+	for field, columnName := range meta.ColumnMapping {
+		if idx, ok := headerIndex[columnName]; ok {
+			columnIndex[field] = idx
+		} else {
+			if field != "description" {
+				return nil, fmt.Errorf("mapped column '%s' not found in statement header", columnName)
+			}
+		}
+	}
+	
+	err = p.validateMappings(columnIndex)
+	if err != nil {
+		return nil, err
+	}
+
+	var transactions []models.CreateTransactionInput
+	for i, row := range preview.Rows {
+		transaction, err := p.parseRow(row, columnIndex)
+		if err != nil {
+			logger.Warnf("skipping row %d due to parsing error: %v", i+meta.SkipRows+2, err)
+			continue
+		}
+		transactions = append(transactions, *transaction)
+	}
+
+	return transactions, nil
+}
+
+func (p *CustomParser) validateMappings(columnIndex map[string]int) error {
+	// Validate that all required fields are present in the column mapping.
+	requiredFields := []string{"txn_date", "name"}
+	for _, f := range requiredFields {
+		if _, ok := columnIndex[f]; !ok {
+			return fmt.Errorf("required field '%s' is not mapped in metadata", f)
+		}
+	}
+	_, amountOk := columnIndex["amount"]
+	_, creditOk := columnIndex["credit"]
+	_, debitOk := columnIndex["debit"]
+	if !amountOk && !(creditOk && debitOk) {
+		return errors.New("insufficient amount information in metadata: map either 'amount' or both 'credit' and 'debit'")
+	}
+	return nil
+}
+
+// parseRow parses a single row into a transaction based on the column index map.
+func (p *CustomParser) parseRow(row []string, columnIndex map[string]int) (*models.CreateTransactionInput, error) {
+	dateStr, err := p.getRequiredField(row, columnIndex, "txn_date")
+	if err != nil {
+		return nil, err
+	}
+	name, err := p.getRequiredField(row, columnIndex, "name")
+	if err != nil {
+		return nil, err
+	}
+	description := p.getOptionalField(row, columnIndex, "description")
+
+	date, err := utils.ParseDate(dateStr)
+	if err != nil {
+		return nil, err
+	}
+
+	amount, err := p.getAmount(row, columnIndex)
+	if err != nil {
+		return nil, err
+	}
+
+	tx := &models.CreateTransactionInput{
+		CreateBaseTransactionInput: models.CreateBaseTransactionInput{
+			Name:        name,
+			Description: description,
+			Amount:      amount,
+			Date:        date,
+		},
+		CategoryIds: []int64{},
+	}
+
+	return tx, nil
+}
+
+func (p *CustomParser) getAmount(row []string, columnIndex map[string]int) (*float64, error) {
+	var amount float64
+	amountStr, amountOk := p.getOptionalFieldOk(row, columnIndex, "amount")
+	creditStr, creditOk := p.getOptionalFieldOk(row, columnIndex, "credit")
+	debitStr, debitOk := p.getOptionalFieldOk(row, columnIndex, "debit")
+
+	if amountOk && amountStr != "" {
+		val, err := utils.ParseFloat(amountStr)
+		if err != nil {
+			return nil, fmt.Errorf("failed to parse amount: %w", err)
+		}
+		amount = val
+	} else if creditOk && debitOk {
+		credit, err := utils.ParseFloat(creditStr)
+		if err != nil && creditStr != "" {
+			return nil, fmt.Errorf("failed to parse credit: %w", err)
+		}
+		debit, err := utils.ParseFloat(debitStr)
+		if err != nil && debitStr != "" {
+			return nil, fmt.Errorf("failed to parse debit: %w", err)
+		}
+
+		if credit > 0 {
+			amount = credit
+		} else {
+			amount = -debit
+		}
+	} else {
+		return nil, errors.New("insufficient amount information: map either 'amount' or both 'credit' and 'debit'")
+	}
+	return &amount, nil
+}
+
+// getRequiredField safely extracts a required field from a row.
+func (p *CustomParser) getRequiredField(row []string, columnIndex map[string]int, fieldName string) (string, error) {
+	idx, ok := columnIndex[fieldName]
+	if !ok {
+		return "", fmt.Errorf("field '%s' is not mapped", fieldName)
+	}
+	if idx >= len(row) {
+		return "", fmt.Errorf("column index %d for '%s' is out of bounds", idx, fieldName)
+	}
+	return row[idx], nil
+}
+
+// getOptionalField safely extracts an optional field from a row.
+func (p *CustomParser) getOptionalField(row []string, columnIndex map[string]int, fieldName string) string {
+	val, _ := p.getOptionalFieldOk(row, columnIndex, fieldName)
+	return val
+}
+
+// getOptionalFieldOk safely extracts an optional field and indicates if the mapping exists.
+func (p *CustomParser) getOptionalFieldOk(row []string, columnIndex map[string]int, fieldName string) (string, bool) {
+	idx, ok := columnIndex[fieldName]
+	if !ok || idx >= len(row) {
+		return "", false
+	}
+	return row[idx], true
+}
+
+func init() {
+	RegisterParser(models.BankTypeOthers, &CustomParser{})
+}

--- a/server/internal/parser/custom_parser.go
+++ b/server/internal/parser/custom_parser.go
@@ -123,7 +123,7 @@ func (p *CustomParser) Parse(fileBytes []byte, metadata string, fileName string)
 			}
 		}
 	}
-	
+
 	err = p.validateMappings(columnIndex)
 	if err != nil {
 		return nil, err

--- a/server/internal/parser/custom_parser_test.go
+++ b/server/internal/parser/custom_parser_test.go
@@ -1,0 +1,285 @@
+package parser
+
+import (
+	"time"
+
+	"expenses/internal/models"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("CustomParser", func() {
+	var p *CustomParser
+
+	BeforeEach(func() {
+		p = &CustomParser{}
+		RegisterParser(models.BankTypeOthers, &CustomParser{})
+	})
+
+	Describe("Preview", func() {
+		Context("with a valid CSV file", func() {
+			csvContent := `Header1,Header2,Header3
+Row1Col1,Row1Col2,Row1Col3
+Row2Col1,Row2Col2,Row2Col3
+Row3Col1,Row3Col2,Row3Col3`
+			fileBytes := []byte(csvContent)
+
+			It("should parse correctly with no rows skipped and all rows returned", func() {
+				preview, err := p.Preview(fileBytes, "test.csv", 0, -1)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(preview.Headers).To(Equal([]string{"Header1", "Header2", "Header3"}))
+				Expect(preview.Rows).To(HaveLen(3))
+				Expect(preview.Rows[0]).To(Equal([]string{"Row1Col1", "Row1Col2", "Row1Col3"}))
+			})
+
+			It("should handle skipping metadata rows before the header", func() {
+				csvWithMeta := `Bank Statement
+Generated on 2023-10-27
+Header1,Header2,Header3
+Row1Col1,Row1Col2,Row1Col3`
+				preview, err := p.Preview([]byte(csvWithMeta), "test.csv", 2, -1)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(preview.Headers).To(Equal([]string{"Header1", "Header2", "Header3"}))
+				Expect(preview.Rows).To(HaveLen(1))
+			})
+
+			It("should limit the number of data rows when rowSize is specified", func() {
+				preview, err := p.Preview(fileBytes, "test.csv", 0, 2)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(preview.Rows).To(HaveLen(2))
+			})
+
+			It("should trim leading and trailing spaces from headers and fields", func() {
+				csvWithSpaces := ` Header1,  Header2  ,Header3
+  Row1Col1  ,Row1Col2  , Row1Col3 `
+				preview, err := p.Preview([]byte(csvWithSpaces), "test.csv", 0, -1)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(preview.Headers).To(Equal([]string{"Header1", "Header2", "Header3"}))
+				Expect(preview.Rows[0]).To(Equal([]string{"Row1Col1", "Row1Col2", "Row1Col3"}))
+			})
+		})
+
+		Context("with a valid XLS file (treated as TSV)", func() {
+			It("should parse a simple file correctly", func() {
+				xlsContent := "Header1\tHeader2\tHeader3\nRow1Col1\tRow1Col2\tRow1Col3"
+				fileBytes := []byte(xlsContent)
+				preview, err := p.Preview(fileBytes, "test.xls", 0, -1)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(preview.Headers).To(Equal([]string{"Header1", "Header2", "Header3"}))
+				Expect(preview.Rows).To(HaveLen(1))
+			})
+
+			It("should parse correctly, respecting skipRows and rowSize", func() {
+				xlsContent := `Bank Statement
+Generated on 2023-10-27
+Header1	Header2	Header3
+Row1Col1	Row1Col2	Row1Col3
+Row2Col1	Row2Col2	Row2Col3
+Row3Col1	Row3Col2	Row3Col3`
+				fileBytes := []byte(xlsContent)
+
+				preview, err := p.Preview(fileBytes, "test.xls", 2, 2)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(preview.Headers).To(Equal([]string{"Header1", "Header2", "Header3"}))
+				Expect(preview.Rows).To(HaveLen(2))
+				Expect(preview.Rows[0]).To(Equal([]string{"Row1Col1", "Row1Col2", "Row1Col3"}))
+				Expect(preview.Rows[1]).To(Equal([]string{"Row2Col1", "Row2Col2", "Row2Col3"}))
+			})
+		})
+
+		Context("with edge cases", func() {
+			It("should return an error for an unsupported file type", func() {
+				_, err := p.Preview([]byte("content"), "statement.pdf", 0, -1)
+				Expect(err).To(HaveOccurred())
+				Expect(err.Error()).To(ContainSubstring("unsupported file type for preview"))
+			})
+
+			It("should handle an empty file", func() {
+				preview, err := p.Preview([]byte(""), "test.csv", 0, -1)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(preview.Headers).To(BeEmpty())
+				Expect(preview.Rows).To(BeEmpty())
+			})
+
+			It("should handle a file with only a header row", func() {
+				preview, err := p.Preview([]byte("Header1,Header2"), "test.csv", 0, -1)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(preview.Headers).To(Equal([]string{"Header1", "Header2"}))
+				Expect(preview.Rows).To(BeEmpty())
+			})
+
+			It("should handle when skipRows is greater than the number of available rows", func() {
+				preview, err := p.Preview([]byte("row1\nrow2"), "test.csv", 5, -1)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(preview.Headers).To(BeEmpty())
+				Expect(preview.Rows).To(BeEmpty())
+			})
+
+			It("should handle rowSize being zero, returning headers but no rows", func() {
+				preview, err := p.Preview([]byte("H1,H2\nR1,R2"), "test.csv", 0, 0)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(preview.Headers).To(Equal([]string{"H1", "H2"}))
+				Expect(preview.Rows).To(BeEmpty())
+			})
+		})
+	})
+
+	Describe("Parse", func() {
+		Context("with valid metadata and file", func() {
+			It("should parse transactions correctly with a single amount column", func() {
+				csvContent := `Date,Payee,Amount
+2024-01-15,Supermarket,150.75`
+				metadata := `{
+					"skip_rows": 0,
+					"column_mapping": { "txn_date": "Date", "name": "Payee", "amount": "Amount" }
+				}`
+				transactions, err := p.Parse([]byte(csvContent), metadata, "test.csv")
+				Expect(err).NotTo(HaveOccurred())
+				Expect(transactions).To(HaveLen(1))
+				Expect(transactions[0].Name).To(Equal("Supermarket"))
+				Expect(transactions[0].Date.Year()).To(Equal(2024))
+				Expect(transactions[0].Date.Month()).To(Equal(time.January))
+				Expect(transactions[0].Date.Day()).To(Equal(15))
+				Expect(*transactions[0].Amount).To(Equal(150.75))
+			})
+
+			It("should parse transactions correctly with separate credit and debit columns", func() {
+				csvContent := `Date,Description,Credit,Debit
+2024-01-17,Salary,5000.00,
+2024-01-18,Groceries,,75.20`
+				metadata := `{
+					"skip_rows": 0,
+					"column_mapping": { "txn_date": "Date", "name": "Description", "credit": "Credit", "debit": "Debit" }
+				}`
+				transactions, err := p.Parse([]byte(csvContent), metadata, "test.csv")
+				Expect(err).NotTo(HaveOccurred())
+				Expect(transactions).To(HaveLen(2))
+				Expect(*transactions[0].Amount).To(Equal(5000.00))
+				Expect(*transactions[1].Amount).To(Equal(-75.20))
+			})
+
+			It("should correctly handle an optional description field when present", func() {
+				csvWithDesc := `Date,Payee,Desc,Amount
+2024-01-15,Supermarket,Weekly Groceries,150.75`
+				metadata := `{
+					"skip_rows": 0,
+					"column_mapping": { "txn_date": "Date", "name": "Payee", "description": "Desc", "amount": "Amount" }
+				}`
+				transactions, err := p.Parse([]byte(csvWithDesc), metadata, "test.csv")
+				Expect(err).NotTo(HaveOccurred())
+				Expect(transactions).To(HaveLen(1))
+				Expect(transactions[0].Description).To(Equal("Weekly Groceries"))
+			})
+
+			It("should correctly skip rows as specified in metadata", func() {
+				csvContent := `Bank Statement
+Account: 12345
+Date,Payee,Amount
+2024-01-15,Supermarket,150.75`
+				metadata := `{
+					"skip_rows": 2,
+					"column_mapping": { "txn_date": "Date", "name": "Payee", "amount": "Amount" }
+				}`
+				transactions, err := p.Parse([]byte(csvContent), metadata, "test.csv")
+				Expect(err).NotTo(HaveOccurred())
+				Expect(transactions).To(HaveLen(1))
+				Expect(transactions[0].Name).To(Equal("Supermarket"))
+			})
+
+			It("should parse correctly when optional description field is not mapped", func() {
+				csvContent := `Date,Payee,Amount
+2024-01-15,Supermarket,150.75`
+				metadata := `{
+					"skip_rows": 0,
+					"column_mapping": { "txn_date": "Date", "name": "Payee", "amount": "Amount" }
+				}`
+				transactions, err := p.Parse([]byte(csvContent), metadata, "test.csv")
+				Expect(err).NotTo(HaveOccurred())
+				Expect(transactions).To(HaveLen(1))
+				Expect(transactions[0].Description).To(BeEmpty())
+			})
+
+			It("should gracefully skip empty or malformed lines", func() {
+				csvContent := `Date,Payee,Amount
+
+2024-01-15,Supermarket,150.75
+
+malformed-line-without-enough-columns
+2024-01-16,Gas Station,45.50
+`
+				metadata := `{
+					"skip_rows": 0,
+					"column_mapping": { "txn_date": "Date", "name": "Payee", "amount": "Amount" }
+				}`
+				transactions, err := p.Parse([]byte(csvContent), metadata, "test.csv")
+				Expect(err).NotTo(HaveOccurred())
+				Expect(transactions).To(HaveLen(2))
+				Expect(transactions[0].Name).To(Equal("Supermarket"))
+				Expect(transactions[1].Name).To(Equal("Gas Station"))
+			})
+		})
+
+		Context("with invalid or problematic data", func() {
+			It("should return an error if metadata is an empty string", func() {
+				_, err := p.Parse([]byte(""), "", "test.csv")
+				Expect(err).To(MatchError("metadata is required for custom parser"))
+			})
+
+			It("should return an error if metadata is not valid JSON", func() {
+				_, err := p.Parse([]byte(""), "{not-json}", "test.csv")
+				Expect(err.Error()).To(ContainSubstring("failed to unmarshal metadata"))
+			})
+
+			It("should return an error if a mapped column is not found in the header", func() {
+				csvContent := `Date,Payee,Value
+2024-01-15,Supermarket,150.75`
+				metadata := `{
+					"skip_rows": 0,
+					"column_mapping": { "txn_date": "Date", "name": "Payee", "amount": "Amount" }
+				}`
+				_, err := p.Parse([]byte(csvContent), metadata, "test.csv")
+				Expect(err).To(MatchError("mapped column 'Amount' not found in statement header"))
+			})
+
+			It("should return an error for insufficient amount information in metadata", func() {
+				csvContent := `Date,Payee,Credit
+2024-01-15,Supermarket,150.75`
+				metadata := `{
+					"skip_rows": 0,
+					"column_mapping": { "txn_date": "Date", "name": "Payee", "credit": "Credit" }
+				}`
+				_, err := p.Parse([]byte(csvContent), metadata, "test.csv")
+				Expect(err).To(MatchError("insufficient amount information in metadata: map either 'amount' or both 'credit' and 'debit'"))
+			})
+
+			It("should return an error if a required field is not mapped in metadata", func() {
+				csvContent := `Date,Amount
+2024-01-15,150.75`
+				metadata := `{
+					"skip_rows": 0,
+					"column_mapping": { "txn_date": "Date", "amount": "Amount" }
+				}`
+				_, err := p.Parse([]byte(csvContent), metadata, "test.csv")
+				Expect(err).To(MatchError("required field 'name' is not mapped in metadata"))
+			})
+
+			It("should skip rows with parsing errors and continue processing valid rows", func() {
+				csvContent := `Date,Payee,Amount
+not-a-date,Supermarket,150.75
+2024-01-16,Gas Station,not-a-number
+2024-01-17,Restaurant,120.00
+2024-01-18,Coffee Shop`
+				metadata := `{
+					"skip_rows": 0,
+					"column_mapping": { "txn_date": "Date", "name": "Payee", "amount": "Amount" }
+				}`
+				transactions, err := p.Parse([]byte(csvContent), metadata, "test.csv")
+				Expect(err).NotTo(HaveOccurred())
+				Expect(transactions).To(HaveLen(1))
+				Expect(transactions[0].Name).To(Equal("Restaurant"))
+				Expect(*transactions[0].Amount).To(Equal(120.00))
+			})
+		})
+	})
+})

--- a/server/internal/parser/registry.go
+++ b/server/internal/parser/registry.go
@@ -2,17 +2,18 @@ package parser
 
 import "expenses/internal/models"
 
-var parserRegistry = make(map[models.BankType]BankStatementParser)
-
-type BankStatementParser interface {
-	Parse(fileBytes []byte) ([]models.CreateTransactionInput, error)
+// Parser defines the interface for different bank statement parsers.
+type Parser interface {
+	Parse(fileBytes []byte, metadata string, fileName string) ([]models.CreateTransactionInput, error)
 }
 
-func RegisterParser(bankType models.BankType, parser BankStatementParser) {
+var parserRegistry = make(map[models.BankType]Parser)
+
+func RegisterParser(bankType models.BankType, parser Parser) {
 	parserRegistry[bankType] = parser
 }
 
-func GetParser(bankType models.BankType) (BankStatementParser, bool) {
+func GetParser(bankType models.BankType) (Parser, bool) {
 	parser, ok := parserRegistry[bankType]
 	return parser, ok
 }

--- a/server/internal/parser/sbi_parser.go
+++ b/server/internal/parser/sbi_parser.go
@@ -15,7 +15,7 @@ import (
 
 type SBIParser struct{}
 
-func (p *SBIParser) Parse(fileBytes []byte) ([]models.CreateTransactionInput, error) {
+func (p *SBIParser) Parse(fileBytes []byte, metadata string, fileName string) ([]models.CreateTransactionInput, error) {
 	scanner := bufio.NewScanner(bytes.NewReader(fileBytes))
 
 	var lines []string

--- a/server/internal/parser/sbi_parser_test.go
+++ b/server/internal/parser/sbi_parser_test.go
@@ -163,7 +163,7 @@ var _ = Describe("SBIParser", func() {
 1 Aug 2022	1 Aug 2022	TO TRANSFER-UPI/DR/221356312527/RITIK  S/SBIN/rs6321908@/UPI--	123456	100.00		1000.00
 2 Aug 2022	2 Aug 2022	BY TRANSFER-NEFT*HDFC0000001*N215222062454075*QURIATE TECHNOLO--	654321		200.00	1200.00
 Computer Generated Statement`
-				txns, err := parser.Parse([]byte(input))
+				txns, err := parser.Parse([]byte(input), "", "")
 				Expect(err).NotTo(HaveOccurred())
 				Expect(txns).To(HaveLen(2))
 				Expect(txns[0].Name).To(Equal("UPI to RITIK  S"))
@@ -176,7 +176,7 @@ Computer Generated Statement`
 				input := `Txn Date	Value Date	Description	Ref No.	Debit	Credit	Balance
 3 Aug 2022	3 Aug 2022	Desc	789012	150.00	200.00	1300.00
 Computer Generated Statement`
-				txns, err := parser.Parse([]byte(input))
+				txns, err := parser.Parse([]byte(input), "", "")
 				Expect(err).NotTo(HaveOccurred())
 				Expect(txns).To(HaveLen(1))
 				Expect(*txns[0].Amount).To(Equal(150.00))
@@ -186,7 +186,7 @@ Computer Generated Statement`
 				input := `Txn Date	Value Date	Description	Ref No.	Debit	Credit	Balance	Extra
 4 Aug 2022	4 Aug 2022	Desc	345678	100.00		1250.00	ExtraValue
 Computer Generated Statement`
-				txns, err := parser.Parse([]byte(input))
+				txns, err := parser.Parse([]byte(input), "", "")
 				Expect(err).NotTo(HaveOccurred())
 				Expect(txns).To(HaveLen(1))
 			})
@@ -194,7 +194,7 @@ Computer Generated Statement`
 			It("should parse row with tabs in description", func() {
 				input := "Txn Date	Value Date	Description	Ref No.	Debit	Credit	Balance\n" +
 					"5 Aug 2022	5 Aug 2022	Desc with	tab	987654	100.00		1175.00\nComputer Generated Statement"
-				txns, err := parser.Parse([]byte(input))
+				txns, err := parser.Parse([]byte(input), "", "")
 				Expect(err).NotTo(HaveOccurred())
 				Expect(txns).To(HaveLen(1))
 			})
@@ -202,7 +202,7 @@ Computer Generated Statement`
 			It("should parse header row with extra whitespace", func() {
 				input := "Txn Date	Value Date	Description	Ref No.	Debit	Credit	Balance\n" +
 					"7 Aug 2022	7 Aug 2022	नमस्ते	123456	100.00		1000.00\nComputer Generated Statement"
-				txns, err := parser.Parse([]byte(input))
+				txns, err := parser.Parse([]byte(input), "", "")
 				Expect(err).NotTo(HaveOccurred())
 				Expect(txns).To(HaveLen(1))
 			})
@@ -210,7 +210,7 @@ Computer Generated Statement`
 			It("should parse row with non-ASCII characters in description", func() {
 				input := "Txn Date	Value Date	Description	Ref No.	Debit	Credit	Balance\n" +
 					"7 Aug 2022	7 Aug 2022	नमस्ते	123456	100.00		1000.00\nComputer Generated Statement"
-				txns, err := parser.Parse([]byte(input))
+				txns, err := parser.Parse([]byte(input), "", "")
 				Expect(err).NotTo(HaveOccurred())
 				Expect(txns).To(HaveLen(1))
 				Expect(txns[0].Name).To(ContainSubstring("नमस्ते"))
@@ -218,7 +218,7 @@ Computer Generated Statement`
 
 			It("should error if header row is missing", func() {
 				input := "No header here\nJust some text"
-				_, err := parser.Parse([]byte(input))
+				_, err := parser.Parse([]byte(input), "", "")
 				Expect(err).To(MatchError(ContainSubstring("transaction header row not found")))
 			})
 
@@ -227,7 +227,7 @@ Computer Generated Statement`
 1 Aug 2022	1 Aug 2022	Desc	123456	100.00		1000.00
 Computer Generated Statement
 2 Aug 2022	2 Aug 2022	Desc	123456	100.00		1000.00`
-				txns, err := parser.Parse([]byte(input))
+				txns, err := parser.Parse([]byte(input), "", "")
 				Expect(err).NotTo(HaveOccurred())
 				Expect(txns).To(HaveLen(1))
 			})
@@ -240,7 +240,7 @@ Computer Generated Statement
  	2 Aug 2022	2 Aug 2022	Desc	123456		200.00	1200.00
 
  	Computer Generated Statement`
-				txns, err := parser.Parse([]byte(input))
+				txns, err := parser.Parse([]byte(input), "", "")
 				Expect(err).NotTo(HaveOccurred())
 				Expect(txns).To(HaveLen(2))
 			})
@@ -250,7 +250,7 @@ Computer Generated Statement
 1 Aug 2022	1 Aug 2022	Short	123456	100.00
 2 Aug 2022	2 Aug 2022	Desc	123456		200.00	1200.00
 Computer Generated Statement`
-				txns, err := parser.Parse([]byte(input))
+				txns, err := parser.Parse([]byte(input), "", "")
 				Expect(err).NotTo(HaveOccurred())
 				Expect(txns).To(HaveLen(1))
 			})
@@ -260,7 +260,7 @@ Computer Generated Statement`
 1 Aug 2022	1 Aug 2022	Desc	123456	abc		1000.00
 2 Aug 2022	2 Aug 2022	Desc	123456		200.00	1200.00
 Computer Generated Statement`
-				txns, err := parser.Parse([]byte(input))
+				txns, err := parser.Parse([]byte(input), "", "")
 				Expect(err).NotTo(HaveOccurred())
 				Expect(txns).To(HaveLen(1))
 			})
@@ -270,7 +270,7 @@ Computer Generated Statement`
  	1 Aug 2022	1 Aug 2022	Desc	123456	abc		1000.00
  	2 Aug 2022	2 Aug 2022	Desc	123456		200.00	1200.00
  	Computer Generated Statement`
-				txns, err := parser.Parse([]byte(input))
+				txns, err := parser.Parse([]byte(input), "", "")
 				Expect(err).NotTo(HaveOccurred())
 				Expect(txns).To(HaveLen(1))
 			})
@@ -280,7 +280,7 @@ Computer Generated Statement`
 1 Aug 2022	1 Aug 2022	Desc		100.00		1000.00
 2 Aug 2022	2 Aug 2022	Desc	654321		200.00	1200.00
 Computer Generated Statement`
-				txns, err := parser.Parse([]byte(input))
+				txns, err := parser.Parse([]byte(input), "", "")
 				Expect(err).NotTo(HaveOccurred())
 				Expect(txns).To(HaveLen(2))
 				Expect(txns[0].Description).To(Equal("Desc"))
@@ -291,7 +291,7 @@ Computer Generated Statement`
 				input := `Txn Date	Value Date	Description	Ref No.	Debit	Credit	Balance
  	1 Aug 2022	1 Aug 2022	Desc	123456	100.00		1000.00
  	Computer Generated Statement`
-				txns, err := parser.Parse([]byte(input))
+				txns, err := parser.Parse([]byte(input), "", "")
 				Expect(err).NotTo(HaveOccurred())
 				Expect(txns).To(HaveLen(1))
 				Expect(txns[0].CategoryIds).To(BeEmpty())

--- a/server/internal/service/statement_service.go
+++ b/server/internal/service/statement_service.go
@@ -45,7 +45,7 @@ func (s *StatementService) ParseStatement(c *gin.Context, input models.ParseStat
 	if err := s.statementValidator.ValidateStatementUpload(input.AccountId, input.FileBytes, input.OriginalFilename); err != nil {
 		return models.StatementResponse{}, err
 	}
-	
+
 	fileType := "csv"
 	if strings.HasSuffix(input.OriginalFilename, ".xls") || strings.HasSuffix(input.OriginalFilename, ".xlsx") {
 		fileType = "excel"
@@ -184,11 +184,11 @@ func (s *StatementService) PreviewStatement(c *gin.Context, fileBytes []byte, fi
 	if rowSize == 0 {
 		rowSize = 10
 	}
-	
+
 	if err := s.statementValidator.ValidateStatementPreview(fileBytes, fileName, skipRows, rowSize); err != nil {
 		return nil, err
 	}
-	
+
 	p := parser.CustomParser{}
 	return p.Preview(fileBytes, fileName, skipRows, rowSize)
 }

--- a/server/internal/wire/wire_gen.go
+++ b/server/internal/wire/wire_gen.go
@@ -10,11 +10,10 @@ import (
 	"expenses/internal/api"
 	"expenses/internal/api/controller"
 	"expenses/internal/config"
-	database "expenses/internal/database/manager"
+	"expenses/internal/database/manager"
 	"expenses/internal/repository"
 	"expenses/internal/service"
 	"expenses/internal/validator"
-
 	"github.com/gin-gonic/gin"
 	"github.com/google/wire"
 )
@@ -43,7 +42,7 @@ func InitializeApplication() (*Provider, error) {
 	ruleServiceInterface := service.NewRuleService(ruleRepositoryInterface, transactionRepositoryInterface, databaseManager)
 	statementRepositoryInterface := repository.NewStatementRepository(databaseManager, configConfig)
 	statementValidator := validator.NewStatementValidator()
-	statementServiceInterface := service.NewStatementService(statementRepositoryInterface, accountRepositoryInterface, statementValidator, transactionServiceInterface)
+	statementServiceInterface := service.NewStatementService(statementRepositoryInterface, accountServiceInterface, statementValidator, transactionServiceInterface)
 	engine := api.Init(configConfig, authServiceInterface, userServiceInterface, accountServiceInterface, categoryServiceInterface, transactionServiceInterface, ruleServiceInterface, statementServiceInterface)
 	provider := NewProvider(engine, databaseManager)
 	return provider, nil

--- a/server/pkg/utils/utils.go
+++ b/server/pkg/utils/utils.go
@@ -2,7 +2,11 @@ package utils
 
 import (
 	"errors"
+	"fmt"
 	"reflect"
+	"strconv"
+	"strings"
+	"time"
 )
 
 // extractFields extracts pointers, values, and column names for exported struct fields.
@@ -77,4 +81,30 @@ func ConvertStruct(src any, dst any) {
 			dstVal.Field(i).Set(srcVal.FieldByName(dstField.Name))
 		}
 	}
+}
+
+// parseDate tries to parse a date string with multiple common layouts.
+func ParseDate(dateStr string) (time.Time, error) {
+	layouts := []string{
+		"2006-01-02", "01-02-2006", "01/02/2006", "2006/01/02",
+		"Jan 2, 2006", "2 Jan 2006", "02 Jan 2006",
+		"January 2, 2006", "2 January 2006", "02 January 2006",
+		time.RFC3339,
+	}
+	for _, layout := range layouts {
+		if t, err := time.Parse(layout, dateStr); err == nil {
+			return t, nil
+		}
+	}
+	return time.Time{}, fmt.Errorf("unable to parse date: %s", dateStr)
+}
+
+// parseAmount cleans and parses a string into a float64.
+func ParseFloat(amountStr string) (float64, error) {
+	if amountStr == "" {
+		return 0, nil
+	}
+	cleanAmount := strings.ReplaceAll(amountStr, ",", "")
+	cleanAmount = strings.TrimSpace(cleanAmount)
+	return strconv.ParseFloat(cleanAmount, 64)
 }

--- a/server/pkg/utils/utils.go
+++ b/server/pkg/utils/utils.go
@@ -99,7 +99,7 @@ func ParseDate(dateStr string) (time.Time, error) {
 	return time.Time{}, fmt.Errorf("unable to parse date: %s", dateStr)
 }
 
-// parseAmount cleans and parses a string into a float64.
+// ParseFloat cleans and parses a string into a float64.
 func ParseFloat(amountStr string) (float64, error) {
 	if amountStr == "" {
 		return 0, nil

--- a/server/pkg/utils/utils_suite_test.go
+++ b/server/pkg/utils/utils_suite_test.go
@@ -220,4 +220,98 @@ var _ = Describe("Utils", func() {
 			})
 		})
 	})
+
+	Describe("ParseDate", func() {
+		expectedDate := time.Date(2023, 10, 26, 0, 0, 0, 0, time.UTC)
+		expectedDateTime := time.Date(2023, 10, 26, 10, 0, 0, 0, time.UTC)
+
+		Context("with valid date strings", func() {
+			// Helper function to compare dates without time
+			dateComparator := func(parsedTime, expectedTime time.Time) bool {
+				y1, m1, d1 := parsedTime.Date()
+				y2, m2, d2 := expectedTime.Date()
+				return y1 == y2 && m1 == m2 && d1 == d2
+			}
+			It("should parse layout 2006-01-02", func() {
+				t, err := ParseDate("2023-10-26")
+				Expect(err).NotTo(HaveOccurred())
+				Expect(dateComparator(t, expectedDate)).To(BeTrue())
+			})
+			It("should parse layout 01-02-2006", func() {
+				t, err := ParseDate("10-26-2023")
+				Expect(err).NotTo(HaveOccurred())
+				Expect(dateComparator(t, expectedDate)).To(BeTrue())
+			})
+			It("should parse layout 01/02/2006", func() {
+				t, err := ParseDate("10/26/2023")
+				Expect(err).NotTo(HaveOccurred())
+				Expect(dateComparator(t, expectedDate)).To(BeTrue())
+			})
+			It("should parse layout Jan 2, 2006", func() {
+				t, err := ParseDate("Oct 26, 2023")
+				Expect(err).NotTo(HaveOccurred())
+				Expect(dateComparator(t, expectedDate)).To(BeTrue())
+			})
+			It("should parse layout RFC3339", func() {
+				t, err := ParseDate("2023-10-26T10:00:00Z")
+				Expect(err).NotTo(HaveOccurred())
+				Expect(t.Equal(expectedDateTime)).To(BeTrue())
+			})
+		})
+
+		Context("with invalid date strings", func() {
+			It("should return an error for an invalid format", func() {
+				_, err := ParseDate("not-a-date")
+				Expect(err).To(HaveOccurred())
+				Expect(err.Error()).To(Equal("unable to parse date: not-a-date"))
+			})
+			It("should return an error for an empty string", func() {
+				_, err := ParseDate("")
+				Expect(err).To(HaveOccurred())
+				Expect(err.Error()).To(Equal("unable to parse date: "))
+			})
+		})
+	})
+
+	Describe("ParseFloat", func() {
+		Context("with valid amount strings", func() {
+			It("should parse a standard float string", func() {
+				f, err := ParseFloat("123.45")
+				Expect(err).NotTo(HaveOccurred())
+				Expect(f).To(Equal(123.45))
+			})
+			It("should parse a string with commas", func() {
+				f, err := ParseFloat("1,234.56")
+				Expect(err).NotTo(HaveOccurred())
+				Expect(f).To(Equal(1234.56))
+			})
+			It("should parse an integer string", func() {
+				f, err := ParseFloat("789")
+				Expect(err).NotTo(HaveOccurred())
+				Expect(f).To(Equal(789.0))
+			})
+			It("should handle leading/trailing spaces", func() {
+				f, err := ParseFloat("  987.65  ")
+				Expect(err).NotTo(HaveOccurred())
+				Expect(f).To(Equal(987.65))
+			})
+			It("should handle a negative number", func() {
+				f, err := ParseFloat("-50.25")
+				Expect(err).NotTo(HaveOccurred())
+				Expect(f).To(Equal(-50.25))
+			})
+			It("should return 0 for an empty string without an error", func() {
+				f, err := ParseFloat("")
+				Expect(err).NotTo(HaveOccurred())
+				Expect(f).To(Equal(0.0))
+			})
+		})
+
+		Context("with an invalid amount string", func() {
+			It("should return an error", func() {
+				_, err := ParseFloat("not-a-number")
+				Expect(err).To(HaveOccurred())
+			})
+		})
+	})
 })


### PR DESCRIPTION
## Description
Most of the times, we might not support the users bank. It is impossible to support all. Hence allow users to upload any CSV, map the rows and use them to parse data automatically


<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Introduce a custom parser for CSV files, allowing users to upload, map, and parse any CSV data, with comprehensive frontend and backend support.
> 
>   - **Frontend**:
>     - Add `ImportStatementModal.tsx` to handle CSV uploads with steps for selecting bank, importing, previewing, and mapping columns.
>     - Add `FallbackParsing.tsx`, `ImportFromBank.tsx`, `MapColumns.tsx`, and `SelectBank.tsx` for step-wise CSV import process.
>     - Update `useStatements.ts` to include `usePreviewStatement` hook.
>   - **Backend**:
>     - Add `PreviewStatement` endpoint in `statement_controller.go` for CSV preview.
>     - Implement `CustomParser` in `custom_parser.go` for parsing CSV with metadata.
>     - Update `statement_service.go` to handle CSV parsing and preview.
>     - Add `ParseStatementInput` and `StatementPreview` models in `statement.go`.
>     - Add validation for CSV files in `statement_validator.go`.
>   - **Tests**:
>     - Add tests for `CustomParser` in `custom_parser_test.go`.
>     - Add tests for `SBIParser` in `sbi_parser_test.go`.
>     - Add tests for `StatementService` in `statement_service_test.go`.
>     - Add tests for `StatementValidator` in `statement_validator_test.go`.
>     - Add utility tests in `utils_suite_test.go`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=trainjumpers%2Fexpenses&utm_source=github&utm_medium=referral)<sup> for e5baf446823d6fa77c0a0f32fc6f77ba0d89f701. You can [customize](https://app.ellipsis.dev/trainjumpers/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->