### PR TITLE
fix: delete category associated to a txn

### DIFF
--- a/frontend/lib/api/account.ts
+++ b/frontend/lib/api/account.ts
@@ -1,6 +1,7 @@
 import { apiRequest } from "@/lib/api/request";
 import { API_BASE_URL } from "@/lib/constants/api";
 import { Account, CreateAccountInput } from "@/lib/models/account";
+import { toast } from "sonner";
 
 export async function listAccounts(signal?: AbortSignal): Promise<Account[]> {
   return apiRequest<Account[]>(
@@ -61,6 +62,22 @@ export async function updateAccount(
 }
 
 export async function deleteAccount(id: number): Promise<void> {
+  const customErrorHandlers = [
+    (response: Response, data: unknown) => {
+      if (response.status === 409) {
+        const errorData = data as { message?: string };
+        if (errorData.message?.includes("existing transactions")) {
+          toast.error(
+            "Cannot delete account with existing transactions",
+            { duration: 2000 }
+          );
+          return true;
+        }
+      }
+      return false;
+    },
+  ];
+
   return apiRequest<void>(
     `${API_BASE_URL}/account/${id}`,
     {
@@ -68,7 +85,7 @@ export async function deleteAccount(id: number): Promise<void> {
       credentials: "include",
     },
     "account",
-    [],
+    customErrorHandlers,
     "Failed to delete account"
   );
 }

--- a/frontend/lib/api/account.ts
+++ b/frontend/lib/api/account.ts
@@ -67,10 +67,9 @@ export async function deleteAccount(id: number): Promise<void> {
       if (response.status === 409) {
         const errorData = data as { message?: string };
         if (errorData.message?.includes("existing transactions")) {
-          toast.error(
-            "Cannot delete account with existing transactions",
-            { duration: 2000 }
-          );
+          toast.error("Cannot delete account with existing transactions", {
+            duration: 2000,
+          });
           return true;
         }
       }

--- a/frontend/lib/types/errors.ts
+++ b/frontend/lib/types/errors.ts
@@ -56,7 +56,16 @@ export interface NotFoundError extends HttpError {
   status: 404;
   data?: {
     message?: string;
-    resource?: string;
+    error?: string;
+  };
+}
+
+// Conflict Error (409 responses)
+export interface ConflictError extends HttpError {
+  status: 409;
+  data?: {
+    message?: string;
+    error?: string;
   };
 }
 
@@ -79,6 +88,7 @@ export type ApiErrorType =
   | AuthError
   | ForbiddenError
   | NotFoundError
+  | ConflictError
   | ServerError;
 
 // Type guard functions
@@ -104,6 +114,10 @@ export function isForbiddenError(error: unknown): error is ForbiddenError {
 
 export function isNotFoundError(error: unknown): error is NotFoundError {
   return isHttpError(error) && error.status === 404;
+}
+
+export function isConflictError(error: unknown): error is ConflictError {
+  return isHttpError(error) && error.status === 409;
 }
 
 export function isServerError(error: unknown): error is ServerError {

--- a/server/internal/api/controller/account_controller_test.go
+++ b/server/internal/api/controller/account_controller_test.go
@@ -382,7 +382,7 @@ var _ = Describe("AccountController", func() {
 				BankType: models.BankTypeAxis,
 				Currency: models.CurrencyINR,
 			}
-			resp, response := testUser1.MakeRequest(http.MethodPost, "/account", input)
+			resp, response := testUser2.MakeRequest(http.MethodPost, "/account", input)
 			Expect(resp.StatusCode).To(Equal(http.StatusCreated))
 			accountId := int64(response["data"].(map[string]any)["id"].(float64))
 
@@ -395,17 +395,17 @@ var _ = Describe("AccountController", func() {
 				Date:      transactionDate,
 				AccountId: accountId,
 			}
-			resp, _ = testUser1.MakeRequest(http.MethodPost, "/transaction", transactionInput)
+			resp, _ = testUser2.MakeRequest(http.MethodPost, "/transaction", transactionInput)
 			Expect(resp.StatusCode).To(Equal(http.StatusCreated))
 
 			// Now try to delete the account - should fail with 409 conflict
 			url := "/account/" + strconv.FormatInt(accountId, 10)
-			resp, response = testUser1.MakeRequest(http.MethodDelete, url, nil)
+			resp, response = testUser2.MakeRequest(http.MethodDelete, url, nil)
 			Expect(resp.StatusCode).To(Equal(http.StatusConflict))
 			Expect(response["message"]).To(Equal("cannot delete account with existing transactions"))
 
 			// Verify account still exists
-			resp, response = testUser1.MakeRequest(http.MethodGet, url, nil)
+			resp, response = testUser2.MakeRequest(http.MethodGet, url, nil)
 			Expect(resp.StatusCode).To(Equal(http.StatusOK))
 			Expect(response["message"]).To(Equal("Account retrieved successfully"))
 		})

--- a/server/internal/api/controller/account_controller_test.go
+++ b/server/internal/api/controller/account_controller_test.go
@@ -4,6 +4,7 @@ import (
 	"expenses/internal/models"
 	"net/http"
 	"strconv"
+	"time"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -372,6 +373,41 @@ var _ = Describe("AccountController", func() {
 			url := "/account/99999"
 			resp, _ := testUser1.MakeRequest(http.MethodDelete, url, nil)
 			Expect(resp.StatusCode).To(Equal(http.StatusNotFound))
+		})
+
+		It("should return 409 conflict when trying to delete account with transactions", func() {
+			// First create an account
+			input := models.CreateAccountInput{
+				Name:     "Account with Transactions",
+				BankType: models.BankTypeAxis,
+				Currency: models.CurrencyINR,
+			}
+			resp, response := testUser1.MakeRequest(http.MethodPost, "/account", input)
+			Expect(resp.StatusCode).To(Equal(http.StatusCreated))
+			accountId := int64(response["data"].(map[string]any)["id"].(float64))
+
+			// Create a transaction for this account
+			amount := 100.50
+			transactionDate, _ := time.Parse("2006-01-02", "2024-01-15")
+			transactionInput := models.CreateBaseTransactionInput{
+				Name:      "Test Transaction",
+				Amount:    &amount,
+				Date:      transactionDate,
+				AccountId: accountId,
+			}
+			resp, _ = testUser1.MakeRequest(http.MethodPost, "/transaction", transactionInput)
+			Expect(resp.StatusCode).To(Equal(http.StatusCreated))
+
+			// Now try to delete the account - should fail with 409 conflict
+			url := "/account/" + strconv.FormatInt(accountId, 10)
+			resp, response = testUser1.MakeRequest(http.MethodDelete, url, nil)
+			Expect(resp.StatusCode).To(Equal(http.StatusConflict))
+			Expect(response["message"]).To(Equal("cannot delete account with existing transactions"))
+
+			// Verify account still exists
+			resp, response = testUser1.MakeRequest(http.MethodGet, url, nil)
+			Expect(resp.StatusCode).To(Equal(http.StatusOK))
+			Expect(response["message"]).To(Equal("Account retrieved successfully"))
 		})
 	})
 

--- a/server/internal/api/controller/category_controller_test.go
+++ b/server/internal/api/controller/category_controller_test.go
@@ -469,7 +469,7 @@ var _ = Describe("CategoryController", func() {
 			updateInput.CategoryIds = &categoryIds
 
 			url := "/transaction/" + strconv.FormatInt(transactionId, 10)
-			resp, response = testUser1.MakeRequest(http.MethodPatch, url, updateInput)
+			resp, _ = testUser1.MakeRequest(http.MethodPatch, url, updateInput)
 			Expect(resp.StatusCode).To(Equal(http.StatusOK))
 
 			// Now delete the category - should succeed despite having transaction mappings
@@ -553,7 +553,7 @@ var _ = Describe("CategoryController", func() {
 
 			// Verify transaction still has the category mapping intact
 			transactionUrl := "/transaction/" + strconv.FormatInt(transactionId, 10)
-			resp, response = testUser1.MakeRequest(http.MethodGet, transactionUrl, nil)
+			resp, _ = testUser1.MakeRequest(http.MethodGet, transactionUrl, nil)
 			Expect(resp.StatusCode).To(Equal(http.StatusOK))
 			responseCategoryIds = response["data"].(map[string]any)["category_ids"].([]any)
 			Expect(len(responseCategoryIds)).To(Equal(1))

--- a/server/internal/api/controller/category_controller_test.go
+++ b/server/internal/api/controller/category_controller_test.go
@@ -4,6 +4,7 @@ import (
 	"expenses/internal/models"
 	"net/http"
 	"strconv"
+	"time"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -425,6 +426,138 @@ var _ = Describe("CategoryController", func() {
 			url := "/category/" + strconv.FormatInt(categoryId, 10)
 			resp, _ := testHelperUnauthenticated.MakeRequest(http.MethodDelete, url, nil)
 			Expect(resp.StatusCode).To(Equal(http.StatusUnauthorized))
+		})
+
+		It("should successfully delete category with transaction mappings", func() {
+			// First create an account
+			accountInput := models.CreateAccountInput{
+				Name:     "Account for Category Test",
+				BankType: models.BankTypeAxis,
+				Currency: models.CurrencyINR,
+			}
+			resp, response := testUser1.MakeRequest(http.MethodPost, "/account", accountInput)
+			Expect(resp.StatusCode).To(Equal(http.StatusCreated))
+			accountId := int64(response["data"].(map[string]any)["id"].(float64))
+
+			// Create a category
+			categoryInput := models.CreateCategoryInput{
+				Name: "Category with Transactions",
+				Icon: "test-icon",
+			}
+			resp, response = testUser1.MakeRequest(http.MethodPost, "/category", categoryInput)
+			Expect(resp.StatusCode).To(Equal(http.StatusCreated))
+			categoryId := int64(response["data"].(map[string]any)["id"].(float64))
+
+			// Create a transaction with this category
+			amount := 100.50
+			transactionDate, _ := time.Parse("2006-01-02", "2024-01-15")
+			transactionInput := models.CreateBaseTransactionInput{
+				Name:      "Test Transaction with Category",
+				Amount:    &amount,
+				Date:      transactionDate,
+				AccountId: accountId,
+			}
+			resp, response = testUser1.MakeRequest(http.MethodPost, "/transaction", transactionInput)
+			Expect(resp.StatusCode).To(Equal(http.StatusCreated))
+			transactionId := int64(response["data"].(map[string]any)["id"].(float64))
+
+			// Update the transaction to include the category (this creates the mapping)
+			updateInput := models.UpdateTransactionInput{
+				UpdateBaseTransactionInput: models.UpdateBaseTransactionInput{},
+			}
+			categoryIds := []int64{categoryId}
+			updateInput.CategoryIds = &categoryIds
+
+			url := "/transaction/" + strconv.FormatInt(transactionId, 10)
+			resp, response = testUser1.MakeRequest(http.MethodPatch, url, updateInput)
+			Expect(resp.StatusCode).To(Equal(http.StatusOK))
+
+			// Now delete the category - should succeed despite having transaction mappings
+			categoryUrl := "/category/" + strconv.FormatInt(categoryId, 10)
+			resp, _ = testUser1.MakeRequest(http.MethodDelete, categoryUrl, nil)
+			Expect(resp.StatusCode).To(Equal(http.StatusNoContent))
+
+			// Verify category is deleted
+			resp, _ = testUser1.MakeRequest(http.MethodGet, categoryUrl, nil)
+			Expect(resp.StatusCode).To(Equal(http.StatusNotFound))
+
+			// Verify transaction still exists but without the category mapping
+			transactionUrl := "/transaction/" + strconv.FormatInt(transactionId, 10)
+			resp, response = testUser1.MakeRequest(http.MethodGet, transactionUrl, nil)
+			Expect(resp.StatusCode).To(Equal(http.StatusOK))
+			responseCategoryIds := response["data"].(map[string]any)["category_ids"].([]any)
+			Expect(len(responseCategoryIds)).To(Equal(0)) // Should have no categories now
+		})
+
+		It("should not delete category with mappings when accessed by different user", func() {
+			// First create an account for user1
+			accountInput := models.CreateAccountInput{
+				Name:     "User1 Account for Category Test",
+				BankType: models.BankTypeAxis,
+				Currency: models.CurrencyINR,
+			}
+			resp, response := testUser1.MakeRequest(http.MethodPost, "/account", accountInput)
+			Expect(resp.StatusCode).To(Equal(http.StatusCreated))
+			accountId := int64(response["data"].(map[string]any)["id"].(float64))
+
+			// Create a category for user1
+			categoryInput := models.CreateCategoryInput{
+				Name: "User1 Category with Transactions",
+				Icon: "user1-icon",
+			}
+			resp, response = testUser1.MakeRequest(http.MethodPost, "/category", categoryInput)
+			Expect(resp.StatusCode).To(Equal(http.StatusCreated))
+			categoryId := int64(response["data"].(map[string]any)["id"].(float64))
+
+			// Create a transaction with this category for user1
+			amount := 150.75
+			transactionDate, _ := time.Parse("2006-01-02", "2024-01-20")
+			transactionInput := models.CreateBaseTransactionInput{
+				Name:      "User1 Transaction with Category",
+				Amount:    &amount,
+				Date:      transactionDate,
+				AccountId: accountId,
+			}
+			resp, response = testUser1.MakeRequest(http.MethodPost, "/transaction", transactionInput)
+			Expect(resp.StatusCode).To(Equal(http.StatusCreated))
+			transactionId := int64(response["data"].(map[string]any)["id"].(float64))
+
+			// Update the transaction to include the category (this creates the mapping)
+			updateInput := models.UpdateTransactionInput{
+				UpdateBaseTransactionInput: models.UpdateBaseTransactionInput{},
+			}
+			categoryIds := []int64{categoryId}
+			updateInput.CategoryIds = &categoryIds
+
+			url := "/transaction/" + strconv.FormatInt(transactionId, 10)
+			resp, response = testUser1.MakeRequest(http.MethodPatch, url, updateInput)
+			Expect(resp.StatusCode).To(Equal(http.StatusOK))
+
+			// Verify the category mapping was created
+			resp, response = testUser1.MakeRequest(http.MethodGet, url, nil)
+			Expect(resp.StatusCode).To(Equal(http.StatusOK))
+			responseCategoryIds := response["data"].(map[string]any)["category_ids"].([]any)
+			Expect(len(responseCategoryIds)).To(Equal(1))
+			Expect(responseCategoryIds[0]).To(Equal(float64(categoryId)))
+
+			// Now try to delete the category as user2 - should fail with 404
+			categoryUrl := "/category/" + strconv.FormatInt(categoryId, 10)
+			resp, response = testUser2.MakeRequest(http.MethodDelete, categoryUrl, nil)
+			Expect(resp.StatusCode).To(Equal(http.StatusNotFound))
+			Expect(response["message"]).To(Equal("category not found"))
+
+			// Verify category still exists for user1
+			resp, response = testUser1.MakeRequest(http.MethodGet, categoryUrl, nil)
+			Expect(resp.StatusCode).To(Equal(http.StatusOK))
+			Expect(response["data"].(map[string]any)["name"]).To(Equal("User1 Category with Transactions"))
+
+			// Verify transaction still has the category mapping intact
+			transactionUrl := "/transaction/" + strconv.FormatInt(transactionId, 10)
+			resp, response = testUser1.MakeRequest(http.MethodGet, transactionUrl, nil)
+			Expect(resp.StatusCode).To(Equal(http.StatusOK))
+			responseCategoryIds = response["data"].(map[string]any)["category_ids"].([]any)
+			Expect(len(responseCategoryIds)).To(Equal(1))
+			Expect(responseCategoryIds[0]).To(Equal(float64(categoryId)))
 		})
 	})
 })

--- a/server/internal/api/controller/transaction_controller_test.go
+++ b/server/internal/api/controller/transaction_controller_test.go
@@ -888,7 +888,7 @@ var _ = Describe("TransactionController", func() {
 			user1TransactionCount := len(transactions)
 
 			// Get all transactions for user 2
-			resp, response = testUser2.MakeRequest(http.MethodGet, "/transaction", nil)
+			resp, response = testUser3.MakeRequest(http.MethodGet, "/transaction", nil)
 			Expect(resp.StatusCode).To(Equal(http.StatusOK))
 			data = response["data"].(map[string]any)
 			transactions = data["transactions"].([]any)
@@ -896,7 +896,7 @@ var _ = Describe("TransactionController", func() {
 
 			// Verify counts match seed data
 			Expect(user1TransactionCount).To(Equal(11))
-			Expect(user2TransactionCount).To(Equal(12)) // 6 from seed data + 6 created during other tests
+			Expect(user2TransactionCount).To(Equal(0)) // they never create any tests
 		})
 	})
 })

--- a/server/internal/errors/account.go
+++ b/server/internal/errors/account.go
@@ -5,3 +5,7 @@ import "net/http"
 func NewAccountNotFoundError(err error) *AuthError {
 	return formatError(http.StatusNotFound, "account not found", err, "AccountNotFound")
 }
+
+func NewAccountHasTransactionsError(err error) *AuthError {
+	return formatError(http.StatusConflict, "cannot delete account with existing transactions", err, "AccountHasTransactions")
+}

--- a/server/internal/repository/account_repository.go
+++ b/server/internal/repository/account_repository.go
@@ -100,6 +100,9 @@ func (r *AccountRepository) DeleteAccount(c *gin.Context, accountId int64, userI
 		r.schema, r.tableName)
 	rowsAffected, err := r.db.ExecuteQuery(c, query, accountId, userId)
 	if err != nil {
+		if customErrors.CheckForeignKey(err, "fk_transaction_account_id") {
+			return customErrors.NewAccountHasTransactionsError(err)
+		}
 		return err
 	}
 	if rowsAffected == 0 {

--- a/server/internal/repository/category_repository.go
+++ b/server/internal/repository/category_repository.go
@@ -131,16 +131,26 @@ func (r *CategoryRepository) UpdateCategory(c *gin.Context, categoryId int64, us
 }
 
 func (r *CategoryRepository) DeleteCategory(c *gin.Context, categoryId int64, userId int64) error {
-	query := fmt.Sprintf(`DELETE FROM %s.%s WHERE id = $1 AND created_by = $2;`, r.schema, r.tableName)
+	// Use a transaction to first delete mappings, then delete the category
+	return r.db.WithTxn(c, func(tx pgx.Tx) error {
+		// Delete all transaction-category mappings for this category
+		deleteMappingsQuery := fmt.Sprintf(`DELETE FROM %s.transaction_category_mapping WHERE category_id = $1;`, r.schema)
+		_, err := tx.Exec(c, deleteMappingsQuery, categoryId)
+		if err != nil {
+			return err
+		}
 
-	rowsAffected, err := r.db.ExecuteQuery(c, query, categoryId, userId)
-	if err != nil {
-		return err
-	}
+		// Now delete the category itself
+		deleteCategoryQuery := fmt.Sprintf(`DELETE FROM %s.%s WHERE id = $1 AND created_by = $2;`, r.schema, r.tableName)
+		result, err := tx.Exec(c, deleteCategoryQuery, categoryId, userId)
+		if err != nil {
+			return err
+		}
 
-	if rowsAffected == 0 {
-		return customErrors.NewCategoryNotFoundError(fmt.Errorf("category with id %d not found", categoryId))
-	}
+		if result.RowsAffected() == 0 {
+			return customErrors.NewCategoryNotFoundError(fmt.Errorf("category with id %d not found", categoryId))
+		}
 
-	return nil
+		return nil
+	})
 }


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Enhance account and category deletion logic to handle transactions, with updated error handling and tests.
> 
>   - **Behavior**:
>     - `deleteAccount` in `account.ts` now handles 409 errors with a toast message if the account has existing transactions.
>     - `DeleteCategory` in `category_repository.go` now deletes transaction-category mappings before deleting the category.
>   - **Error Handling**:
>     - Adds `ConflictError` type and `isConflictError` function in `errors.ts`.
>     - Adds `NewAccountHasTransactionsError` in `account.go` for handling 409 errors.
>   - **Tests**:
>     - Adds test for 409 conflict in `account_controller_test.go` when deleting an account with transactions.
>     - Adds test for successful category deletion with transaction mappings in `category_controller_test.go`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=trainjumpers%2Fexpenses&utm_source=github&utm_medium=referral)<sup> for 26f78dc627944948dfe0a76f1f96061f59413e16. You can [customize](https://app.ellipsis.dev/trainjumpers/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->