### PR TITLE
feat: allow for having 'OR' condition for rules

### DIFF
--- a/frontend/components/custom/Modal/Rule/EditRuleModal.tsx
+++ b/frontend/components/custom/Modal/Rule/EditRuleModal.tsx
@@ -48,12 +48,7 @@ export function EditRuleModal({
       .then((data: DescribeRuleResponse) => {
         // Prepare initial data for RuleModal
         setInitialData({
-          rule: {
-            name: data.rule.name || "",
-            description: data.rule.description || "",
-            effective_from:
-              data.rule.effective_from || new Date().toISOString().slice(0, 10),
-          },
+          rule: data.rule,
           conditions: normalizeRuleConditions(
             data.conditions as BaseRuleCondition[],
             []

--- a/frontend/components/custom/Modal/Rule/components/RuleConditions.tsx
+++ b/frontend/components/custom/Modal/Rule/components/RuleConditions.tsx
@@ -2,6 +2,7 @@ import { RuleInput } from "@/components/custom/Modal/Rule/components/RuleInput";
 import { Button } from "@/components/ui/button";
 import {
   BaseRuleCondition,
+  ConditionLogic,
   RULE_FIELD_TYPES,
   RULE_OPERATORS,
   RuleFieldType,
@@ -12,12 +13,16 @@ import { Plus, Trash2 } from "lucide-react";
 interface RuleConditionsProps {
   conditions: BaseRuleCondition[];
   onConditionsChange: (conditions: BaseRuleCondition[]) => void;
+  conditionLogic: ConditionLogic;
+  onConditionLogicChange: (logic: ConditionLogic) => void;
   disabled?: boolean;
 }
 
 export function RuleConditions({
   conditions,
   onConditionsChange,
+  conditionLogic,
+  onConditionLogicChange,
   disabled = false,
 }: RuleConditionsProps) {
   const handleAddCondition = () => {
@@ -49,13 +54,28 @@ export function RuleConditions({
   return (
     <div className="space-y-4">
       <h3 className="text-lg font-semibold">IF</h3>
-      <div className="space-y-3">
+      <div className="flex items-center gap-2 text-sm">
+        <span>Match</span>
+        <select
+          value={conditionLogic}
+          onChange={(e) =>
+            onConditionLogicChange(e.target.value as ConditionLogic)
+          }
+          disabled={disabled || conditions.length < 2}
+          className="px-2 py-1 bg-background border border-border rounded-lg focus:outline-none focus:ring-2 focus:ring-ring"
+        >
+          <option value={ConditionLogic.AND}>All</option>
+          <option value={ConditionLogic.OR}>Any</option>
+        </select>
+        <span>of the following conditions:</span>
+      </div>
+      <div className="space-y-3 pl-4 border-l-2">
         {conditions.map((condition, idx) => (
           <div key={idx} className="space-y-3">
             {idx > 0 && (
               <div className="flex items-center">
                 <span className="text-sm font-medium text-muted-foreground bg-muted px-2 py-1 rounded">
-                  AND
+                  {conditionLogic}
                 </span>
               </div>
             )}
@@ -117,18 +137,18 @@ export function RuleConditions({
             </div>
           </div>
         ))}
-      </div>
-      <div className="flex items-center gap-4">
-        <Button
-          variant="ghost"
-          size="sm"
-          onClick={handleAddCondition}
-          disabled={disabled}
-          className="text-muted-foreground hover:text-foreground"
-        >
-          <Plus className="h-4 w-4 mr-2" />
-          Add condition
-        </Button>
+        <div className="flex items-center gap-4">
+          <Button
+            variant="ghost"
+            size="sm"
+            onClick={handleAddCondition}
+            disabled={disabled}
+            className="text-muted-foreground hover:text-foreground"
+          >
+            <Plus className="h-4 w-4 mr-2" />
+            Add condition
+          </Button>
+        </div>
       </div>
     </div>
   );

--- a/frontend/lib/models/rule.ts
+++ b/frontend/lib/models/rule.ts
@@ -1,3 +1,8 @@
+export enum ConditionLogic {
+  AND = "AND",
+  OR = "OR",
+}
+
 export type RuleFieldType = "amount" | "name" | "description" | "category";
 export type RuleOperator = "equals" | "contains" | "greater" | "lower";
 
@@ -18,6 +23,7 @@ export const RULE_OPERATORS: { label: string; value: RuleOperator }[] = [
 export interface BaseRule {
   name: string;
   description?: string;
+  condition_logic?: ConditionLogic;
   effective_from: string;
 }
 
@@ -49,6 +55,7 @@ export type UpdateRuleConditionInput = Partial<CreateRuleConditionInput>;
 export interface Rule extends BaseRule {
   id: number;
   created_by: number;
+  condition_logic: ConditionLogic;
 }
 
 export interface RuleAction extends BaseRuleAction {

--- a/server/internal/database/migrations/00009_add_condition_logic_to_rules.sql
+++ b/server/internal/database/migrations/00009_add_condition_logic_to_rules.sql
@@ -1,0 +1,11 @@
+-- +goose Up
+-- +goose StatementBegin
+ALTER TABLE ${DB_SCHEMA}.rule
+ADD COLUMN condition_logic VARCHAR(3) NOT NULL DEFAULT 'AND' CHECK (condition_logic IN ('AND', 'OR'));
+-- +goose StatementEnd
+
+-- +goose Down
+-- +goose StatementBegin
+ALTER TABLE ${DB_SCHEMA}.rule
+DROP COLUMN condition_logic;
+-- +goose StatementEnd

--- a/server/internal/models/rule.go
+++ b/server/internal/models/rule.go
@@ -6,6 +6,7 @@ import (
 
 type RuleFieldType string
 type RuleOperator string
+type ConditionLogic string
 
 const (
 	RuleFieldAmount      RuleFieldType = "amount"
@@ -21,11 +22,17 @@ const (
 	OperatorLower    RuleOperator = "lower"
 )
 
+const (
+	ConditionLogicAnd ConditionLogic = "AND"
+	ConditionLogicOr  ConditionLogic = "OR"
+)
+
 type CreateBaseRuleRequest struct {
-	Name          string    `json:"name" binding:"required,min=1,max=100"`
-	Description   *string   `json:"description,omitempty" binding:"omitempty,max=255"`
-	EffectiveFrom time.Time `json:"effective_from" binding:"required"`
-	CreatedBy     int64     `json:"created_by"`
+	Name           string          `json:"name" binding:"required,min=1,max=100"`
+	Description    *string         `json:"description,omitempty" binding:"omitempty,max=255"`
+	ConditionLogic *ConditionLogic `json:"condition_logic" binding:"omitempty,oneof=AND OR"`
+	EffectiveFrom  time.Time       `json:"effective_from" binding:"required"`
+	CreatedBy      int64           `json:"created_by"`
 }
 
 type CreateRuleRequest struct {
@@ -35,17 +42,19 @@ type CreateRuleRequest struct {
 }
 
 type UpdateRuleRequest struct {
-	Name          *string    `json:"name,omitempty" binding:"omitempty,max=100"`
-	Description   *string    `json:"description,omitempty" binding:"omitempty,max=255"`
-	EffectiveFrom *time.Time `json:"effective_from,omitempty"`
+	Name           *string         `json:"name,omitempty" binding:"omitempty,max=100"`
+	Description    *string         `json:"description,omitempty" binding:"omitempty,max=255"`
+	ConditionLogic *ConditionLogic `json:"condition_logic" binding:"omitempty,oneof=AND OR"`
+	EffectiveFrom  *time.Time      `json:"effective_from,omitempty"`
 }
 
 type RuleResponse struct {
-	Id            int64     `json:"id"`
-	Name          string    `json:"name"`
-	Description   *string   `json:"description"`
-	EffectiveFrom time.Time `json:"effective_from"`
-	CreatedBy     int64     `json:"created_by"`
+	Id             int64          `json:"id"`
+	Name           string         `json:"name"`
+	Description    *string        `json:"description"`
+	ConditionLogic ConditionLogic `json:"condition_logic"`
+	EffectiveFrom  time.Time      `json:"effective_from"`
+	CreatedBy      int64          `json:"created_by"`
 }
 
 type DescribeRuleResponse struct {


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Adds support for 'OR' condition logic in rules, updating models, controllers, and tests to handle the new logic alongside existing 'AND' logic.
> 
>   - **Behavior**:
>     - Adds support for 'OR' condition logic in rules, alongside existing 'AND' logic.
>     - Default logic is 'AND' if not specified.
>     - Updates `RuleModal` and `EditRuleModal` to handle `condition_logic`.
>   - **Models**:
>     - Adds `ConditionLogic` enum to `models/rule.ts` and `models/rule.go`.
>     - Updates `BaseRule` and `Rule` interfaces to include `condition_logic`.
>   - **Database**:
>     - Adds `condition_logic` column to `rule` table with migration `00009_add_condition_logic_to_rules.sql`.
>   - **Controllers**:
>     - Updates rule creation and update endpoints to handle `condition_logic`.
>     - Validates `condition_logic` values in `rule_controller_test.go`.
>   - **Service**:
>     - Updates `RuleEngine` to evaluate conditions based on `condition_logic`.
>     - Implements `evaluateAndConditions` and `evaluateOrConditions` in `rule_engine.go`.
>   - **Tests**:
>     - Adds tests for `AND` and `OR` logic in `rule_engine_test.go` and `rule_controller_test.go`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=trainjumpers%2Fexpenses&utm_source=github&utm_medium=referral)<sup> for 748532d98e5b1dabc1cda0994d5a74d189194a90. You can [customize](https://app.ellipsis.dev/trainjumpers/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->