### PR TITLE
fix: run rules after parsing all statement

### DIFF
--- a/server/internal/service/rule_engine_service.go
+++ b/server/internal/service/rule_engine_service.go
@@ -11,6 +11,7 @@ import (
 
 type RuleEngineServiceInterface interface {
 	ExecuteRules(ctx context.Context, userId int64, request models.ExecuteRulesRequest) (models.ExecuteRulesResponse, error)
+	ExecuteRulesInBackground(ctx context.Context, userId int64, request models.ExecuteRulesRequest)
 }
 
 type ruleEngineService struct {
@@ -32,12 +33,12 @@ func NewRuleEngineService(
 }
 
 func (s *ruleEngineService) ExecuteRules(ctx context.Context, userId int64, request models.ExecuteRulesRequest) (models.ExecuteRulesResponse, error) {
-	go s.executeRulesInBackground(context.Background(), userId, request)
+	go s.ExecuteRulesInBackground(context.Background(), userId, request)
 	logger.Infof("Rule execution started in background for user %d", userId)
 	return models.ExecuteRulesResponse{}, nil
 }
 
-func (s *ruleEngineService) executeRulesInBackground(ctx context.Context, userId int64, request models.ExecuteRulesRequest) {
+func (s *ruleEngineService) ExecuteRulesInBackground(ctx context.Context, userId int64, request models.ExecuteRulesRequest) {
 	logger.Infof("Executing rules for user %d", userId)
 
 	// Step 1: Fetch all categories

--- a/server/internal/service/statement_service.go
+++ b/server/internal/service/statement_service.go
@@ -148,13 +148,19 @@ func (s *StatementService) processStatementAsync(ctx context.Context, statementI
 	if failCount == len(parsedTxs) {
 		status = models.StatementStatusError
 	}
-	_, _ = s.repo.UpdateStatementStatus(ctx, statementId, models.UpdateStatementStatusInput{
+	_, err = s.repo.UpdateStatementStatus(ctx, statementId, models.UpdateStatementStatusInput{
 		Status:  status,
 		Message: &msg,
 	})
+	if err != nil {
+		logger.Errorf("Failed to update statement status for ID %d: %v", statementId)
+	}
 	_, err = s.ruleEngineService.ExecuteRules(ctx, userId, models.ExecuteRulesRequest{
 		TransactionIds: &txnIds,
 	})
+	if err != nil {
+		logger.Errorf("Failed to execute rules for transactions: %v", err)
+	}
 }
 
 func (s *StatementService) GetStatementStatus(ctx context.Context, statementId int64, userId int64) (models.StatementResponse, error) {

--- a/server/internal/service/statement_service.go
+++ b/server/internal/service/statement_service.go
@@ -148,18 +148,15 @@ func (s *StatementService) processStatementAsync(ctx context.Context, statementI
 	if failCount == len(parsedTxs) {
 		status = models.StatementStatusError
 	}
+	s.ruleEngineService.ExecuteRulesInBackground(ctx, userId, models.ExecuteRulesRequest{
+		TransactionIds: &txnIds,
+	})
 	_, err = s.repo.UpdateStatementStatus(ctx, statementId, models.UpdateStatementStatusInput{
 		Status:  status,
 		Message: &msg,
 	})
 	if err != nil {
 		logger.Errorf("Failed to update statement status for ID %d: %v", statementId, err)
-	}
-	_, err = s.ruleEngineService.ExecuteRules(ctx, userId, models.ExecuteRulesRequest{
-		TransactionIds: &txnIds,
-	})
-	if err != nil {
-		logger.Errorf("Failed to execute rules for transactions: %v", err)
 	}
 }
 

--- a/server/internal/service/statement_service.go
+++ b/server/internal/service/statement_service.go
@@ -153,7 +153,7 @@ func (s *StatementService) processStatementAsync(ctx context.Context, statementI
 		Message: &msg,
 	})
 	if err != nil {
-		logger.Errorf("Failed to update statement status for ID %d: %v", statementId)
+		logger.Errorf("Failed to update statement status for ID %d: %v", statementId, err)
 	}
 	_, err = s.ruleEngineService.ExecuteRules(ctx, userId, models.ExecuteRulesRequest{
 		TransactionIds: &txnIds,

--- a/server/internal/service/statement_service_test.go
+++ b/server/internal/service/statement_service_test.go
@@ -15,13 +15,13 @@ import (
 
 var _ = Describe("StatementService", func() {
 	var (
-		mockRepo       *repository.MockStatementRepository
-		service        StatementService
-		txnService     TransactionServiceInterface
-		accountService AccountServiceInterface
+		mockRepo          *repository.MockStatementRepository
+		service           StatementService
+		txnService        TransactionServiceInterface
+		accountService    AccountServiceInterface
 		ruleEngineService RuleEngineServiceInterface
-		userId         int64
-		ctx            context.Context
+		userId            int64
+		ctx               context.Context
 	)
 
 	BeforeEach(func() {

--- a/server/internal/service/statement_service_test.go
+++ b/server/internal/service/statement_service_test.go
@@ -19,6 +19,7 @@ var _ = Describe("StatementService", func() {
 		service        StatementService
 		txnService     TransactionServiceInterface
 		accountService AccountServiceInterface
+		ruleEngineService RuleEngineServiceInterface
 		userId         int64
 		ctx            context.Context
 	)
@@ -30,14 +31,17 @@ var _ = Describe("StatementService", func() {
 		mockCategoryRepo := repository.NewMockCategoryRepository()
 		mockAccountRepo := repository.NewMockAccountRepository()
 		mockDbManager := mockDatabase.NewMockDatabaseManager()
+		mockRuleRepo := repository.NewMockRuleRepository()
 		txnService = NewTransactionService(mockTxnRepo, mockCategoryRepo, mockAccountRepo, mockDbManager)
 		accountService = NewAccountService(mockAccountRepo)
+		ruleEngineService = NewRuleEngineService(mockRuleRepo, mockTxnRepo, mockCategoryRepo)
 
 		service = StatementService{
 			repo:               mockRepo,
 			statementValidator: validator.NewStatementValidator(),
 			txService:          txnService,
 			accountService:     accountService,
+			ruleEngineService:  ruleEngineService,
 		}
 		userId = 42
 	})

--- a/server/internal/wire/wire_gen.go
+++ b/server/internal/wire/wire_gen.go
@@ -43,7 +43,7 @@ func InitializeApplication() (*Provider, error) {
 	ruleEngineServiceInterface := service.NewRuleEngineService(ruleRepositoryInterface, transactionRepositoryInterface, categoryRepositoryInterface)
 	statementRepositoryInterface := repository.NewStatementRepository(databaseManager, configConfig)
 	statementValidator := validator.NewStatementValidator()
-	statementServiceInterface := service.NewStatementService(statementRepositoryInterface, accountServiceInterface, statementValidator, transactionServiceInterface)
+	statementServiceInterface := service.NewStatementService(statementRepositoryInterface, accountServiceInterface, ruleEngineServiceInterface, statementValidator, transactionServiceInterface)
 	analyticsRepositoryInterface := repository.NewAnalyticsRepository(databaseManager, configConfig)
 	analyticsServiceInterface := service.NewAnalyticsService(analyticsRepositoryInterface, accountRepositoryInterface)
 	engine := api.Init(configConfig, authServiceInterface, userServiceInterface, accountServiceInterface, categoryServiceInterface, transactionServiceInterface, ruleServiceInterface, ruleEngineServiceInterface, statementServiceInterface, analyticsServiceInterface)


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Add `ExecuteRulesInBackground` to `RuleEngineServiceInterface` and update `StatementService` to execute rules after parsing transactions.
> 
>   - **Behavior**:
>     - Add `ExecuteRulesInBackground` to `RuleEngineServiceInterface` in `rule_engine_service.go`.
>     - Update `processStatementAsync()` in `statement_service.go` to call `ExecuteRulesInBackground` after parsing transactions.
>   - **Dependency Injection**:
>     - Update `NewStatementService` in `statement_service.go` to include `RuleEngineServiceInterface`.
>     - Modify `InitializeApplication` in `wire_gen.go` to pass `ruleEngineServiceInterface` to `NewStatementService`.
>   - **Testing**:
>     - Update `statement_service_test.go` to include `RuleEngineServiceInterface` in test setup.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=trainjumpers%2Fexpenses&utm_source=github&utm_medium=referral)<sup> for 3ac1933a52288c9f0e7ae138cda26bba4e28546f. You can [customize](https://app.ellipsis.dev/trainjumpers/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->