### PR TITLE
fix: add partitioned field to cookies

### DIFF
--- a/server/internal/api/controller/base_controller.go
+++ b/server/internal/api/controller/base_controller.go
@@ -191,6 +191,9 @@ func (b *BaseController) setAuthCookie(ctx *gin.Context, name, value string, max
 	}
 	// Gin's SetCookie does not support SameSite, so use Header directly
 	h := cookie.String()
+	if !strings.Contains(h, "Partitioned") {
+		h = h + "; Partitioned"
+	}
 	ctx.Writer.Header().Add("Set-Cookie", h)
 }
 


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Adds 'Partitioned' attribute to cookies in `setAuthCookie()` if not already present.
> 
>   - **Behavior**:
>     - Adds 'Partitioned' attribute to cookies in `setAuthCookie()` in `base_controller.go` if not already present.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=trainjumpers%2Fexpenses&utm_source=github&utm_medium=referral)<sup> for 0b07076e65066f422185b68818f5605a522a1dd6. You can [customize](https://app.ellipsis.dev/trainjumpers/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->