### PR TITLE
feat: add short currency formatting and tooltips in accounts analytics sidepanel

### DIFF
--- a/frontend/components/custom/Dashboard/AccountsAnalyticsSidepanel.tsx
+++ b/frontend/components/custom/Dashboard/AccountsAnalyticsSidepanel.tsx
@@ -6,7 +6,8 @@ import { useAccountAnalytics } from "@/components/hooks/useAnalytics";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Skeleton } from "@/components/ui/skeleton";
-import { formatCurrency, formatPercentage } from "@/lib/utils";
+import { formatCurrency, formatShortCurrency, formatPercentage } from "@/lib/utils";
+import { Tooltip, TooltipTrigger, TooltipContent, TooltipProvider } from "@/components/ui/tooltip";
 import { Plus } from "lucide-react";
 import { useState } from "react";
 
@@ -204,16 +205,28 @@ export function AccountsAnalyticsSidepanel({
 
                             <div className="text-right">
                               <div className="font-semibold text-sm">
-                                {formatCurrency(
-                                  account.balance,
-                                  account.currency
-                                )}
+                                <TooltipProvider>
+                                  <Tooltip>
+                                    <TooltipTrigger asChild>
+                                      <span>{formatShortCurrency(account.balance, account.currency)}</span>
+                                    </TooltipTrigger>
+                                    <TooltipContent side="top">
+                                      {formatCurrency(account.balance, account.currency)}
+                                    </TooltipContent>
+                                  </Tooltip>
+                                </TooltipProvider>
                                 <span className="text-xs text-muted-foreground ml-2">
                                   •{" "}
-                                  {formatCurrency(
-                                    account.txnBalance,
-                                    account.currency
-                                  )}
+                                  <TooltipProvider>
+                                    <Tooltip>
+                                      <TooltipTrigger asChild>
+                                        <span>{formatShortCurrency(account.txnBalance, account.currency)}</span>
+                                      </TooltipTrigger>
+                                      <TooltipContent side="top">
+                                        {formatCurrency(account.txnBalance, account.currency)}
+                                      </TooltipContent>
+                                    </Tooltip>
+                                  </TooltipProvider>
                                 </span>
                               </div>
                               <div
@@ -260,10 +273,16 @@ export function AccountsAnalyticsSidepanel({
 
                             <div className="text-right">
                               <div className="font-semibold text-sm">
-                                {formatCurrency(
-                                  account.balance,
-                                  account.currency
-                                )}
+                                <TooltipProvider>
+                                  <Tooltip>
+                                    <TooltipTrigger asChild>
+                                      <span>{formatShortCurrency(account.balance, account.currency)}</span>
+                                    </TooltipTrigger>
+                                    <TooltipContent side="top">
+                                      {formatCurrency(account.balance, account.currency)}
+                                    </TooltipContent>
+                                  </Tooltip>
+                                </TooltipProvider>
                               </div>
                               <div
                                 className={`text-xs ${

--- a/frontend/components/custom/Dashboard/AccountsAnalyticsSidepanel.tsx
+++ b/frontend/components/custom/Dashboard/AccountsAnalyticsSidepanel.tsx
@@ -68,7 +68,7 @@ export function AccountsAnalyticsSidepanel({
         analytics.current_value !== null &&
         analytics.current_value !== undefined;
       const percentageChange = isInvestment
-        ? (-1 * (analytics.percentage_increase ?? 0))
+        ? -1 * (analytics.percentage_increase ?? 0)
         : calculatePercentageChange(
             analytics.current_balance,
             analytics.balance_one_month_ago

--- a/frontend/components/ui/tooltip.tsx
+++ b/frontend/components/ui/tooltip.tsx
@@ -17,9 +17,15 @@ function TooltipProvider({
   );
 }
 
-function Tooltip({
-  ...props
-}: React.ComponentProps<typeof TooltipPrimitive.Root>) {
+type TooltipProps = React.ComponentProps<typeof TooltipPrimitive.Root> & {
+  skipProvider?: boolean;
+};
+
+function Tooltip({ skipProvider = false, ...props }: TooltipProps) {
+  if (skipProvider) {
+    return <TooltipPrimitive.Root data-slot="tooltip" {...props} />;
+  }
+
   return (
     <TooltipProvider>
       <TooltipPrimitive.Root data-slot="tooltip" {...props} />
@@ -51,7 +57,7 @@ function TooltipContent({
         {...props}
       >
         {children}
-        <TooltipPrimitive.Arrow className="bg-foreground fill-foreground z-50 size-2.5 translate-y-[calc(-50%_-_2px)] rotate-45 rounded-[2px]" />
+        <TooltipPrimitive.Arrow className="bg-foreground fill-foreground z-50 size-2.5 translate-y-[calc(-50%-2px)] rotate-45 rounded-[2px]" />
       </TooltipPrimitive.Content>
     </TooltipPrimitive.Portal>
   );

--- a/frontend/lib/utils.ts
+++ b/frontend/lib/utils.ts
@@ -17,6 +17,46 @@ export const formatCurrency = (
   }).format(amount);
 };
 
+export const formatShortCurrency = (
+  amount: number,
+  currency: string = "INR"
+): string => {
+  const abs = Math.abs(amount);
+  const sign = amount < 0 ? "-" : "";
+
+  // Extract a narrow currency symbol (e.g., ₹)
+  const currencySymbol = new Intl.NumberFormat("en-IN", {
+    style: "currency",
+    currency,
+    currencyDisplay: "narrowSymbol",
+    minimumFractionDigits: 0,
+    maximumFractionDigits: 0,
+  })
+    .format(0)
+    .replace(/0/g, "")
+    .trim();
+
+  if (!isFinite(abs)) return formatCurrency(amount, currency);
+
+  if (abs >= 1e7) {
+    const v = (abs / 1e7).toFixed(1).replace(/\.0$/, "");
+    return `${sign}${currencySymbol}${v} Cr`;
+  }
+
+  if (abs >= 1e5) {
+    const v = (abs / 1e5).toFixed(1).replace(/\.0$/, "");
+    return `${sign}${currencySymbol}${v}L`;
+  }
+
+  if (abs >= 1e3) {
+    const v = (abs / 1e3).toFixed(1).replace(/\.0$/, "");
+    return `${sign}${currencySymbol}${v}K`;
+  }
+
+  // For small numbers, show the standard formatted currency
+  return formatCurrency(amount, currency);
+};
+
 export const formatPercentage = (percentage: number): string => {
   const sign = percentage > 0 ? "+" : "";
   return `${sign}${percentage.toFixed(1)}%`;

--- a/frontend/lib/utils.ts
+++ b/frontend/lib/utils.ts
@@ -40,7 +40,7 @@ export const formatShortCurrency = (
 
   if (abs >= 1e7) {
     const v = (abs / 1e7).toFixed(1).replace(/\.0$/, "");
-    return `${sign}${currencySymbol}${v} Cr`;
+    return `${sign}${currencySymbol}${v}Cr`;
   }
 
   if (abs >= 1e5) {


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Adds short currency formatting and tooltips to Accounts Analytics Sidepanel for improved UI clarity.
> 
>   - **Behavior**:
>     - Adds `formatShortCurrency` to `utils.ts` for short currency formatting (e.g., 1.2K, 3.4L).
>     - Integrates tooltips in `AccountsAnalyticsSidepanel.tsx` to show full currency values on hover.
>     - Adjusts `percentageChange` calculation for investments in `AccountsAnalyticsSidepanel.tsx`.
>   - **UI Components**:
>     - Updates `Tooltip` in `tooltip.tsx` to support `skipProvider` prop for nested tooltips.
>     - Adds `TooltipProvider` wrapping in `AccountsAnalyticsSidepanel.tsx` for consistent tooltip behavior.
>   - **Misc**:
>     - Adds `getTransactionColor` to `utils.ts` for dynamic text color based on transaction value.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=trainjumpers%2Fexpenses&utm_source=github&utm_medium=referral)<sup> for daefd7c59c5ddcc809630e3e25c855ec9f8482e1. You can [customize](https://app.ellipsis.dev/trainjumpers/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->