### PR TITLE
Potential fixes for 2 code quality findings

### DIFF
--- a/server/internal/parser/axis_parser_test.go
+++ b/server/internal/parser/axis_parser_test.go
@@ -85,8 +85,9 @@ Tran Date,CHQNO,PARTICULARS,DR,CR,BAL,SOL
 		})
 
 		It("should return error for CSV without a recognizable header", func() {
-			csvContent := `random,values,only
-31-03-2025,1,2,3,4,5`
+			csvContent := `date,ref,description,debit,credit,balance,sol
+31-03-2025,-,TEST_DESC_1,1000.00, ,9000.00,1234
+01-04-2025,-,TEST_DESC_2, ,500.00,9500.00,1234`
 			fileBytes := []byte(csvContent)
 			txns, err := parser.Parse(fileBytes, "", "bad.csv", "")
 			Expect(err).To(HaveOccurred())

--- a/server/internal/parser/axis_parser_test.go
+++ b/server/internal/parser/axis_parser_test.go
@@ -108,7 +108,7 @@ Tran Date,CHQNO,PARTICULARS,DR,CR,BAL,SOL
 			res, err := parser.parseTransactionRow(fields)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(res).NotTo(BeNil())
-			// Name should be prefixed with Debit and truncated to 40 runes (37 + "...")
+			// Name should be prefixed with Debit and truncated to 37 runes, then "..." appended (37 + 3 = 40 runes total)
 			Expect(strings.HasPrefix(res.Name, "Debit: ")).To(BeTrue())
 			Expect(strings.HasSuffix(res.Name, "...")).To(BeTrue())
 			Expect(len([]rune(res.Name))).To(Equal(40))


### PR DESCRIPTION
_This PR applies 2/3 suggestions from code quality [AI findings](https://github.com/trainjumpers/expenses/security/quality/ai-findings). 1 suggestion was skipped to avoid creating conflicts._